### PR TITLE
Fixing "Blender" example issue regarding number of threads and enclave size

### DIFF
--- a/ci/stage-test-sgx.jenkinsfile
+++ b/ci/stage-test-sgx.jenkinsfile
@@ -1,4 +1,5 @@
 stage('test-sgx') {
+    env.no_cpu = sh(script:'nproc', returnStdout: true).trim()
     try {
         timeout(time: 60, unit: 'MINUTES') {
             sh '''
@@ -162,11 +163,24 @@ stage('test-sgx') {
 
     try {    
         timeout(time: 5, unit: 'MINUTES') {
-            sh '''
+        if(env.no_cpu.toInteger() > 16)
+            {
+                sh '''
+                cd Examples/blender
+                sed -i 's/sgx.enclave_size = "2048M"/sgx.enclave_size = "4G"/g' blender.manifest.template
+                sed -i 's/sgx.thread_num = 64/sgx.thread_num = 256/g' blender.manifest.template
+                make ${MAKEOPTS} all
+                make ${MAKEOPTS} SGX=1 check
+                '''		
+            }
+            else
+            {
+                sh '''
                 cd Examples/blender
                 make ${MAKEOPTS} all
                 make ${MAKEOPTS} SGX=1 check
-            '''
+                '''
+            }
         }
     } catch (Exception e){
         env.build_ok = false

--- a/ci/stage-test-sgx.jenkinsfile
+++ b/ci/stage-test-sgx.jenkinsfile
@@ -163,24 +163,16 @@ stage('test-sgx') {
 
     try {    
         timeout(time: 5, unit: 'MINUTES') {
-        if(env.no_cpu.toInteger() > 16)
-            {
-                sh '''
-                cd Examples/blender
-                sed -i 's/sgx.enclave_size = "2048M"/sgx.enclave_size = "4G"/g' blender.manifest.template
-                sed -i 's/sgx.thread_num = 64/sgx.thread_num = 256/g' blender.manifest.template
-                make ${MAKEOPTS} all
-                make ${MAKEOPTS} SGX=1 check
-                '''		
-            }
-            else
-            {
-                sh '''
-                cd Examples/blender
-                make ${MAKEOPTS} all
-                make ${MAKEOPTS} SGX=1 check
-                '''
-            }
+            sh '''
+            cd Examples/blender
+            if [ "${no_cpu}" -gt 16 ]
+            then
+                sed -i "s/sgx.enclave_size = "2048M"/sgx.enclave_size = "4G"/g" blender.manifest.template
+                sed -i "s/sgx.thread_num = 64/sgx.thread_num = 256/g" blender.manifest.template
+            fi
+            make ${MAKEOPTS} all
+            make ${MAKEOPTS} SGX=1 check	
+            '''
         }
     } catch (Exception e){
         env.build_ok = false


### PR DESCRIPTION
In this commit, the number of threads and enclave size is based on the number of processing units