### PR TITLE
Adding the ARCH_LIBDIR option for CentOS

### DIFF
--- a/ci/stage-test-direct.jenkinsfile
+++ b/ci/stage-test-direct.jenkinsfile
@@ -1,4 +1,10 @@
 stage('test-direct') {
+    env.gcc_dump_machine = sh(script:'gcc -dumpmachine', returnStdout: true).trim()
+    env.ARCH_LIB_OPT = ""
+    if(env.gcc_dump_machine == "x86_64-redhat-linux") 
+    {
+        env.ARCH_LIB_OPT = "ARCH_LIBDIR=/lib64"
+    }
     try {
         timeout(time: 30, unit: 'MINUTES') {
             sh '''
@@ -27,7 +33,7 @@ stage('test-direct') {
         timeout(time: 5, unit: 'MINUTES') {
             sh '''
                 cd Examples/python
-                make ${MAKEOPTS} all
+                make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make check
             '''
         }
@@ -40,7 +46,7 @@ stage('test-direct') {
         timeout(time: 5, unit: 'MINUTES') {
             sh '''
                 cd Examples/bash
-                make ${MAKEOPTS} all
+                make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make ${MAKEOPTS} regression
             '''
         }
@@ -53,7 +59,7 @@ stage('test-direct') {
         timeout(time: 5, unit: 'MINUTES') {
             sh '''
                 cd Examples/curl
-                make ${MAKEOPTS} all
+                make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make ${MAKEOPTS} check
             '''
         }
@@ -66,7 +72,7 @@ stage('test-direct') {
         timeout(time: 5, unit: 'MINUTES') {
             sh '''
                 cd Examples/gcc
-                make ${MAKEOPTS} all
+                make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make ${MAKEOPTS} check
             '''
         }
@@ -79,7 +85,7 @@ stage('test-direct') {
         timeout(time: 10, unit: 'MINUTES') {
             sh '''
                 cd Examples/memcached
-                make ${MAKEOPTS} all
+                make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make start-graphene-server &
                 ../../Scripts/wait_for_server 5 127.0.0.1 11211
                 # memcslap populates server but doesn't report errors, use
@@ -102,7 +108,7 @@ stage('test-direct') {
                     USE_SELECT=1
                     export USE_SELECT
                 fi
-                make ${MAKEOPTS} all
+                make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make start-graphene-server &
                 ../../Scripts/wait_for_server 5 127.0.0.1 6379
                 ./src/src/redis-benchmark
@@ -117,7 +123,7 @@ stage('test-direct') {
         timeout(time: 10, unit: 'MINUTES') {
             sh '''
                 cd Examples/lighttpd
-                make ${MAKEOPTS} all
+                make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make ${MAKEOPTS} start-graphene-server &
                 ../../Scripts/wait_for_server 5 127.0.0.1 8003
                 LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh 127.0.0.1:8003
@@ -132,7 +138,7 @@ stage('test-direct') {
         timeout(time: 10, unit: 'MINUTES') {
             sh '''
                 cd Examples/nginx
-                make ${MAKEOPTS} all
+                make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make ${MAKEOPTS} start-graphene-server &
                 ../../Scripts/wait_for_server 5 127.0.0.1 8002
                 LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh 127.0.0.1:8002
@@ -161,7 +167,7 @@ stage('test-direct') {
         timeout(time: 5, unit: 'MINUTES') {
             sh '''
                 cd Examples/blender
-                make ${MAKEOPTS} all
+                make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make check
             '''
         }
@@ -174,7 +180,7 @@ stage('test-direct') {
         timeout(time: 5, unit: 'MINUTES') {
             sh '''
                 cd Examples/r
-                make ${MAKEOPTS} all
+                make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make check
             '''
         }

--- a/ci/stage-test-sgx.jenkinsfile
+++ b/ci/stage-test-sgx.jenkinsfile
@@ -1,4 +1,10 @@
 stage('test-sgx') {
+    env.gcc_dump_machine = sh(script:'gcc -dumpmachine', returnStdout: true).trim()
+    env.ARCH_LIB_OPT = ""
+    if(env.gcc_dump_machine == "x86_64-redhat-linux") 
+    {
+        env.ARCH_LIB_OPT = "ARCH_LIBDIR=/lib64"
+    }    
     env.no_cpu = sh(script:'nproc', returnStdout: true).trim()
     try {
         timeout(time: 60, unit: 'MINUTES') {
@@ -28,7 +34,7 @@ stage('test-sgx') {
         timeout(time: 5, unit: 'MINUTES') {
             sh '''
                 cd Examples/python
-                make ${MAKEOPTS} all
+                make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make ${MAKEOPTS} SGX=1 check
             '''
         }
@@ -41,7 +47,7 @@ stage('test-sgx') {
         timeout(time: 5, unit: 'MINUTES') {
             sh '''
                 cd Examples/bash
-                make ${MAKEOPTS} all
+                make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make ${MAKEOPTS} SGX=1 regression
             '''
         }
@@ -54,7 +60,7 @@ stage('test-sgx') {
         timeout(time: 5, unit: 'MINUTES') {
             sh '''
                 cd Examples/curl
-                make ${MAKEOPTS} all
+                make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make ${MAKEOPTS} SGX=1 check
             '''
         }
@@ -67,7 +73,7 @@ stage('test-sgx') {
         timeout(time: 10, unit: 'MINUTES') {
             sh '''
                 cd Examples/gcc
-                make ${MAKEOPTS} all
+                make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make ${MAKEOPTS} SGX=1 check
             '''
         }
@@ -80,7 +86,7 @@ stage('test-sgx') {
         timeout(time: 15, unit: 'MINUTES') {
             sh '''
                 cd Examples/memcached
-                make ${MAKEOPTS} all
+                make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make SGX=1 start-graphene-server &
                 ../../Scripts/wait_for_server 60 127.0.0.1 11211
                 # memcslap populates server but doesn't report errors, use
@@ -106,7 +112,7 @@ stage('test-sgx') {
                 fi
 
                 cd Examples/redis
-                make ${MAKEOPTS}
+                make ${MAKEOPTS} ${ARCH_LIB_OPT}
                 make ${MAKEOPTS} SGX=1 start-graphene-server &
                 ../../Scripts/wait_for_server 60 127.0.0.1 6379
                 ./src/src/redis-benchmark
@@ -121,7 +127,7 @@ stage('test-sgx') {
         timeout(time: 15, unit: 'MINUTES') {
             sh '''
                 cd Examples/lighttpd
-                make ${MAKEOPTS} all
+                make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make ${MAKEOPTS} SGX=1 start-graphene-server &
                 ../../Scripts/wait_for_server 60 127.0.0.1 8003
                 LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh 127.0.0.1:8003
@@ -136,7 +142,7 @@ stage('test-sgx') {
         timeout(time: 15, unit: 'MINUTES') {
             sh '''
                 cd Examples/nginx
-                make ${MAKEOPTS} all
+                make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make ${MAKEOPTS} SGX=1 start-graphene-server &
                 ../../Scripts/wait_for_server 60 127.0.0.1 8002
                 LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh 127.0.0.1:8002
@@ -170,7 +176,7 @@ stage('test-sgx') {
                 sed -i "s/sgx.enclave_size = "2048M"/sgx.enclave_size = "4G"/g" blender.manifest.template
                 sed -i "s/sgx.thread_num = 64/sgx.thread_num = 256/g" blender.manifest.template
             fi
-            make ${MAKEOPTS} all
+            make ${MAKEOPTS} ${ARCH_LIB_OPT} all
             make ${MAKEOPTS} SGX=1 check	
             '''
         }
@@ -183,7 +189,7 @@ stage('test-sgx') {
         timeout(time: 5, unit: 'MINUTES') {
             sh '''
                 cd Examples/r
-                make ${MAKEOPTS} all
+                make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make ${MAKEOPTS} SGX=1 check
             '''
         }


### PR DESCRIPTION
In this commit, the ARCH_LIBDIR option which is
required for x86_64-redhat-linux machines, is added