### PR TITLE
Fix for 'sed' command issue in "Blender"

### DIFF
--- a/ci/stage-test-sgx.jenkinsfile
+++ b/ci/stage-test-sgx.jenkinsfile
@@ -173,8 +173,8 @@ stage('test-sgx') {
             cd Examples/blender
             if [ "${no_cpu}" -gt 16 ]
             then
-                sed -i "s/sgx.enclave_size = "2048M"/sgx.enclave_size = "4G"/g" blender.manifest.template
-                sed -i "s/sgx.thread_num = 64/sgx.thread_num = 256/g" blender.manifest.template
+                sed -i 's/sgx.enclave_size = "2048M"/sgx.enclave_size = "4G"/g' blender.manifest.template
+                sed -i 's/sgx.thread_num = 64/sgx.thread_num = 256/g' blender.manifest.template
             fi
             make ${MAKEOPTS} ${ARCH_LIB_OPT} all
             make ${MAKEOPTS} SGX=1 check	


### PR DESCRIPTION
In this commit, the issue is resolved by putting single quotes instead of double quotes.