### PR TITLE
Bypassing  the execve03 error issue due to read ELF header

### DIFF
--- a/ltp_config/runltp_tests.py
+++ b/ltp_config/runltp_tests.py
@@ -340,8 +340,10 @@ class TestRunner:
         for error in error_list:
             if error == "":
                 pass
-            elif "Using insecure argv source" in error or "error: Mounting file:/proc may expose unsanitized" in error:
-                pass
+            elif "Using insecure argv source" in error or \
+                "error: Mounting file:/proc may expose unsanitized" in error or \
+                "error: Failed to read ELF header" in error:
+                pass 
             else:
                 raise Fail('Error Message={}'.format(error))
 


### PR DESCRIPTION
In this commit, the read ELF header error is bypassed, if the required testcases are executed successfully