### PR TITLE
Bypassing disallowing access error message for clock_gettime04

### DIFF
--- a/ltp_config/runltp_tests.py
+++ b/ltp_config/runltp_tests.py
@@ -342,7 +342,10 @@ class TestRunner:
                 pass
             elif "Using insecure argv source" in error or \
                 "error: Mounting file:/proc may expose unsanitized" in error or \
-                "error: Failed to read ELF header" in error:
+                "error: Failed to read ELF header" in error or \
+                "Disallowing access to file '/usr/bin/systemd-detect-virt'" in error or \
+                "Disallowing access to file '/lib64/libtinfo.so.6'" in error or \
+                "Disallowing access to file '/usr/lib64/libtinfo.so.6'" in error:
                 pass 
             else:
                 raise Fail('Error Message={}'.format(error))


### PR DESCRIPTION
In this commit, the disallowing access error message is bypassed if all the testcases are executed successfully.