### PR TITLE
Bypassing error message

### DIFF
--- a/ltp_config/runltp_tests.py
+++ b/ltp_config/runltp_tests.py
@@ -346,6 +346,7 @@ class TestRunner:
                 "Disallowing access to file '/usr/bin/systemd-detect-virt'" in error or \
                 "Disallowing access to file '/lib64/libtinfo.so.6'" in error or \
                 "Disallowing access to file '/usr/lib64/libtinfo.so.6'" in error or \
+                "Detected deprecated syntax. Consider switching to new syntax: 'sgx.allowed_files" in error or \
                 "error: Mounting file:/dev/cpu_dma_latency may expose unsanitized" in error :
                 pass 
             else:


### PR DESCRIPTION
In this commit, the error regarding "Detected deprecated syntax" is bypassed.