### PR TITLE
Renaming "Examples", remove and add Examples and skip mkdir09 TC

### DIFF
--- a/ci/linux-direct-centos8.2-gcc-release.jenkinsfile
+++ b/ci/linux-direct-centos8.2-gcc-release.jenkinsfile
@@ -15,7 +15,7 @@ node(node_label) {
         dir ("gramine") {
             sh 'cp -rf $WORKSPACE/ltp_src LibOS/shim/test/ltp/'
             sh 'cp -rf $WORKSPACE/ltp_config/* LibOS/shim/test/ltp/'
-            sh 'cp -rf $WORKSPACE/stress-ng Examples/'
+            sh 'cp -rf $WORKSPACE/stress-ng CI-Examples/'
             sh 'cp -f $WORKSPACE/test_workloads.py . '
             env.WORKSPACE = env.WORKSPACE + "/gramine"
 
@@ -33,7 +33,7 @@ node(node_label) {
             load '../ci/config-docker.jenkinsfile'
 
             if (env.gcc_dump_machine == "x86_64-redhat-linux") {  
-                sh 'sed -i -e \'/dist\\|apport/c\\\' $WORKSPACE/Examples/python/python.manifest.template'
+                sh 'sed -i -e \'/dist\\|apport/c\\\' $WORKSPACE/CI-Examples/python/python.manifest.template'
             }
 
             load '.ci/lib/config.jenkinsfile'

--- a/ci/linux-direct-ubuntu18.04-gcc-release.jenkinsfile
+++ b/ci/linux-direct-ubuntu18.04-gcc-release.jenkinsfile
@@ -15,7 +15,7 @@ node(node_label) {
         dir ("gramine") {
             sh 'cp -rf $WORKSPACE/ltp_src LibOS/shim/test/ltp/'
             sh 'cp -rf $WORKSPACE/ltp_config/* LibOS/shim/test/ltp/'
-            sh 'cp -rf $WORKSPACE/stress-ng Examples/'
+            sh 'cp -rf $WORKSPACE/stress-ng CI-Examples/'
             sh 'cp -f $WORKSPACE/test_workloads.py . '
             env.WORKSPACE = env.WORKSPACE + "/gramine"
 

--- a/ci/linux-direct-ubuntu20.04-gcc-release.jenkinsfile
+++ b/ci/linux-direct-ubuntu20.04-gcc-release.jenkinsfile
@@ -15,7 +15,7 @@ node(node_label) {
         dir ("gramine") {
             sh 'cp -rf $WORKSPACE/ltp_src LibOS/shim/test/ltp/'
             sh 'cp -rf $WORKSPACE/ltp_config/* LibOS/shim/test/ltp/'
-            sh 'cp -rf $WORKSPACE/stress-ng Examples/'
+            sh 'cp -rf $WORKSPACE/stress-ng CI-Examples/'
             sh 'cp -f $WORKSPACE/test_workloads.py . '
             env.WORKSPACE = env.WORKSPACE + "/gramine"
 

--- a/ci/linux-sgx-centos8.2-gcc-release.jenkinsfile
+++ b/ci/linux-sgx-centos8.2-gcc-release.jenkinsfile
@@ -15,7 +15,7 @@ node (node_label) {
         dir ("gramine") {
             sh 'cp -rf $WORKSPACE/ltp_src LibOS/shim/test/ltp/'
             sh 'cp -rf $WORKSPACE/ltp_config/* LibOS/shim/test/ltp/'
-            sh 'cp -rf $WORKSPACE/stress-ng Examples/'
+            sh 'cp -rf $WORKSPACE/stress-ng CI-Examples/'
             sh 'cp -f $WORKSPACE/test_workloads.py . '
             env.WORKSPACE = env.WORKSPACE + "/gramine"
             env.SGX = '1'
@@ -34,7 +34,7 @@ node (node_label) {
             load '../ci/config-docker.jenkinsfile'
 
             if (env.gcc_dump_machine == "x86_64-redhat-linux") {  
-                sh 'sed -i -e \'/dist\\|apport/c\\\' $WORKSPACE/Examples/python/python.manifest.template'
+                sh 'sed -i -e \'/dist\\|apport/c\\\' $WORKSPACE/CI-Examples/python/python.manifest.template'
             }
             
             load '.ci/lib/config.jenkinsfile'

--- a/ci/linux-sgx-ubuntu18.04-gcc-release-apps.jenkinsfile
+++ b/ci/linux-sgx-ubuntu18.04-gcc-release-apps.jenkinsfile
@@ -12,12 +12,12 @@ node (node_label) {
         }
 
         dir ("gramine") {
-            sh 'cp -rf $WORKSPACE/stress-ng Examples/'
+            sh 'cp -rf $WORKSPACE/stress-ng CI-Examples/'
             env.WORKSPACE = env.WORKSPACE + "/gramine"
             env.SGX = '1'
 
             load '../ci/config-docker.jenkinsfile'
-            sh 'cp -rf ~/jenkins/sandstone-50-bin $WORKSPACE/Examples'
+            sh 'cp -rf ~/jenkins/sandstone-50-bin $WORKSPACE/CI-Examples'
 
             docker.build(
                 "local:${env.BUILD_TAG}",

--- a/ci/linux-sgx-ubuntu18.04-gcc-release.jenkinsfile
+++ b/ci/linux-sgx-ubuntu18.04-gcc-release.jenkinsfile
@@ -15,7 +15,7 @@ node (node_label) {
         dir ("gramine") {
             sh 'cp -rf $WORKSPACE/ltp_src LibOS/shim/test/ltp/'
             sh 'cp -rf $WORKSPACE/ltp_config/* LibOS/shim/test/ltp/'
-            sh 'cp -rf $WORKSPACE/stress-ng Examples/'
+            sh 'cp -rf $WORKSPACE/stress-ng CI-Examples/'
             sh 'cp -f $WORKSPACE/test_workloads.py . '
             env.WORKSPACE = env.WORKSPACE + "/gramine"
             env.SGX = '1'

--- a/ci/linux-sgx-ubuntu18.04-stress-ng.jenkinsfile
+++ b/ci/linux-sgx-ubuntu18.04-stress-ng.jenkinsfile
@@ -12,12 +12,12 @@ node (node_label) {
         }
 
         dir ("gramine") {
-            sh 'cp -rf $WORKSPACE/stress-ng Examples/'
+            sh 'cp -rf $WORKSPACE/stress-ng CI-Examples/'
             env.WORKSPACE = env.WORKSPACE + "/gramine"
             env.SGX = '1'
 
             load '../ci/config-docker.jenkinsfile'
-            //sh 'cp -rf ~/jenkins/sandstone-50-bin $WORKSPACE/Examples'
+            //sh 'cp -rf ~/jenkins/sandstone-50-bin $WORKSPACE/CI-Examples'
 
             docker.build(
                 "local:${env.BUILD_TAG}",

--- a/ci/linux-sgx-ubuntu20.04-gcc-release-apps.jenkinsfile
+++ b/ci/linux-sgx-ubuntu20.04-gcc-release-apps.jenkinsfile
@@ -12,12 +12,12 @@ node (node_label) {
         }
 
         dir ("gramine") {
-            sh 'cp -rf $WORKSPACE/stress-ng Examples/'
+            sh 'cp -rf $WORKSPACE/stress-ng CI-Examples/'
             env.WORKSPACE = env.WORKSPACE + "/gramine"
             env.SGX = '1'
 
             load '../ci/config-docker.jenkinsfile'
-            sh 'cp -rf ~/jenkins/sandstone-50-bin $WORKSPACE/Examples'
+            sh 'cp -rf ~/jenkins/sandstone-50-bin $WORKSPACE/CI-Examples'
 
             docker.build(
                 "local:${env.BUILD_TAG}",

--- a/ci/linux-sgx-ubuntu20.04-gcc-release.jenkinsfile
+++ b/ci/linux-sgx-ubuntu20.04-gcc-release.jenkinsfile
@@ -15,7 +15,7 @@ node(node_label) {
         dir ("gramine") {
             sh 'cp -rf $WORKSPACE/ltp_src LibOS/shim/test/ltp/'
             sh 'cp -rf $WORKSPACE/ltp_config/* LibOS/shim/test/ltp/'
-            sh 'cp -rf $WORKSPACE/stress-ng Examples/'
+            sh 'cp -rf $WORKSPACE/stress-ng CI-Examples/'
             sh 'cp -f $WORKSPACE/test_workloads.py . '
             env.WORKSPACE = env.WORKSPACE + "/gramine"
             env.SGX = '1'

--- a/ci/stage-test-direct.jenkinsfile
+++ b/ci/stage-test-direct.jenkinsfile
@@ -26,7 +26,7 @@ stage('test-direct') {
     try{
         timeout(time: 5, unit: 'MINUTES') {
             sh '''
-                cd Examples/python
+                cd CI-Examples/python
                 make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make check
             '''
@@ -39,7 +39,7 @@ stage('test-direct') {
     try{
         timeout(time: 5, unit: 'MINUTES') {
             sh '''
-                cd Examples/bash
+                cd CI-Examples/bash
                 sed -i '/@rm OUTPUT/d' Makefile
                 make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make ${MAKEOPTS} regression
@@ -50,38 +50,12 @@ stage('test-direct') {
         sh 'echo "Bash Example Test Failed"'
     }
 
-    try {
-        timeout(time: 5, unit: 'MINUTES') {
-            sh '''
-                cd Examples/curl
-                sed -i '/@rm OUTPUT/d' Makefile
-                make ${MAKEOPTS} ${ARCH_LIB_OPT} all
-                make ${MAKEOPTS} check
-            '''
-        }
-    } catch (Exception e){
-        env.build_ok = false
-        sh 'echo "Curl Example Test Failed"'
-    }
     if(env.gcc_dump_machine != "x86_64-redhat-linux") 
     {
         try {
-            timeout(time: 5, unit: 'MINUTES') {
-                sh '''
-                    cd Examples/gcc
-                    make ${MAKEOPTS} ${ARCH_LIB_OPT} all
-                    make ${MAKEOPTS} check
-                '''
-            }
-        } catch (Exception e){
-            env.build_ok = false
-            sh 'echo "GCC Example Test Failed"'
-        }
-
-        try {
             timeout(time: 10, unit: 'MINUTES') {
                 sh '''
-                    cd Examples/memcached
+                    cd CI-Examples/memcached
                     make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                     make start-graphene-server &
                     ../../Scripts/wait_for_server 5 127.0.0.1 11211
@@ -100,7 +74,7 @@ stage('test-direct') {
     try {
         timeout(time: 10, unit: 'MINUTES') {
             sh '''
-                cd Examples/redis
+                cd CI-Examples/redis
                 if .ci/isdistro xenial
                 then
                     USE_SELECT=1
@@ -120,7 +94,7 @@ stage('test-direct') {
     try {
         timeout(time: 10, unit: 'MINUTES') {
             sh '''
-                cd Examples/lighttpd
+                cd CI-Examples/lighttpd
                 make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make ${MAKEOPTS} start-graphene-server &
                 ../../Scripts/wait_for_server 5 127.0.0.1 8003
@@ -135,7 +109,7 @@ stage('test-direct') {
     try {
         timeout(time: 10, unit: 'MINUTES') {
             sh '''
-                cd Examples/nginx
+                cd CI-Examples/nginx
                 make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make ${MAKEOPTS} start-graphene-server &
                 ../../Scripts/wait_for_server 5 127.0.0.1 8002
@@ -147,24 +121,10 @@ stage('test-direct') {
         sh 'echo "NGINX Example Test Failed"'
     }
 
-        /*
-        timeout(time: 20, unit: 'MINUTES') {
-            sh '''
-                cd Examples/apache
-                make ${MAKEOPTS} all
-                make ${MAKEOPTS} start-graphene-server &
-                ../../Scripts/wait_for_server 5 127.0.0.1 8001
-                LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh 127.0.0.1:8001
-                ../../Scripts/wait_for_server 5 127.0.0.1 8443
-                LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh https://127.0.0.1:8443
-            '''
-        }
-        */
-
     try {    
         timeout(time: 5, unit: 'MINUTES') {
             sh '''
-                cd Examples/blender
+                cd CI-Examples/blender
                 make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make check
             '''
@@ -174,18 +134,17 @@ stage('test-direct') {
         sh 'echo "Blender Example Test Failed"'
     }
 
-    try {
+    try{
         timeout(time: 5, unit: 'MINUTES') {
             sh '''
-                cd Examples/r
-                sed -i '/@$(RM) OUTPUT/d' Makefile
+                cd CI-Examples/sqlite
                 make ${MAKEOPTS} ${ARCH_LIB_OPT} all
-                make check
+                make ${MAKEOPTS} regression
             '''
         }
     } catch (Exception e){
         env.build_ok = false
-        sh 'echo "R Example Test Failed"'
+        sh 'echo "SQLite Example Test Failed"'
     }
 
     try {

--- a/ci/stage-test-sandstone.jenkinsfile
+++ b/ci/stage-test-sandstone.jenkinsfile
@@ -1,7 +1,7 @@
 stage('test') {
     timeout(time: 90, unit: 'MINUTES') {
         sh '''
-            cd Examples/sandstone-50-bin
+            cd CI-Examples/sandstone-50-bin
             if test -n "$SGX"
             then
                 make SGX=1 

--- a/ci/stage-test-sgx.jenkinsfile
+++ b/ci/stage-test-sgx.jenkinsfile
@@ -29,7 +29,7 @@ stage('test-sgx') {
     try{
         timeout(time: 5, unit: 'MINUTES') {
             sh '''
-                cd Examples/python
+                cd CI-Examples/python
                 make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make ${MAKEOPTS} SGX=1 check
             '''
@@ -42,7 +42,7 @@ stage('test-sgx') {
     try{
         timeout(time: 5, unit: 'MINUTES') {
             sh '''
-                cd Examples/bash
+                cd CI-Examples/bash
                 sed -i '/@rm OUTPUT/d' Makefile
                 make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make ${MAKEOPTS} SGX=1 regression
@@ -52,43 +52,13 @@ stage('test-sgx') {
         env.build_ok = false
         sh 'echo "Bash Example Test Failed"'
     }
-
-    try {
-        timeout(time: 5, unit: 'MINUTES') {
-            sh '''
-                cd Examples/curl
-                sed -i '/@rm OUTPUT/d' Makefile
-                if [ "${gcc_dump_machine}" == 'x86_64-redhat-linux' ]
-                then
-                    sed -i '$ a loader.pal_internal_mem_size = "64M"' curl.manifest.template 
-                fi
-                make ${MAKEOPTS} ${ARCH_LIB_OPT} all
-                make ${MAKEOPTS} SGX=1 check
-            '''
-        }
-    } catch (Exception e){
-        env.build_ok = false
-        sh 'echo "Curl Example Test Failed"'
-    }
+ 
     if(env.gcc_dump_machine != "x86_64-redhat-linux") 
     {  
         try {
-            timeout(time: 10, unit: 'MINUTES') {
-                sh '''
-                    cd Examples/gcc
-                    make ${MAKEOPTS} ${ARCH_LIB_OPT} all
-                    make ${MAKEOPTS} SGX=1 check
-                '''
-            }
-        } catch (Exception e){
-            env.build_ok = false
-            sh 'echo "GCC Example Test Failed"'
-        }
-
-        try {
             timeout(time: 15, unit: 'MINUTES') {
                 sh '''
-                    cd Examples/memcached
+                    cd CI-Examples/memcached
                     make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                     make SGX=1 start-graphene-server &
                     ../../Scripts/wait_for_server 60 127.0.0.1 11211
@@ -115,7 +85,7 @@ stage('test-sgx') {
                     export USE_SELECT
                 fi
 
-                cd Examples/redis
+                cd CI-Examples/redis
                 if [ "${gcc_dump_machine}" == 'x86_64-redhat-linux' ]
                 then
                     sed -i '$ a loader.pal_internal_mem_size = "64M"' redis-server.manifest.template 
@@ -134,7 +104,7 @@ stage('test-sgx') {
     try {
         timeout(time: 15, unit: 'MINUTES') {
             sh '''
-                cd Examples/lighttpd
+                cd CI-Examples/lighttpd
                 if [ "${gcc_dump_machine}" == 'x86_64-redhat-linux' ]
                 then
                     sed -i '$ a loader.pal_internal_mem_size = "64M"' lighttpd.manifest.template 
@@ -153,7 +123,7 @@ stage('test-sgx') {
     try {
         timeout(time: 15, unit: 'MINUTES') {
             sh '''
-                cd Examples/nginx
+                cd CI-Examples/nginx
                 if [ "${gcc_dump_machine}" == 'x86_64-redhat-linux' ]
                 then
                     sed -i '$ a loader.pal_internal_mem_size = "64M"' nginx.manifest.template 
@@ -169,24 +139,10 @@ stage('test-sgx') {
         sh 'echo "NGINX Example Test Failed"'
     }
 
-        /*
-        timeout(time: 25, unit: 'MINUTES') {
-            sh '''
-                cd Examples/apache
-                make ${MAKEOPTS} all
-                make ${MAKEOPTS} start-graphene-server &
-                ../../Scripts/wait_for_server 60 127.0.0.1 8001
-                LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh 127.0.0.1:8001
-                ../../Scripts/wait_for_server 60 127.0.0.1 8443
-                LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh https://127.0.0.1:8443
-            '''
-        }
-        */
-
     try {    
         timeout(time: 5, unit: 'MINUTES') {
             sh '''
-            cd Examples/blender
+            cd CI-Examples/blender
             if [ "${no_cpu}" -gt 16 ]
             then
                 sed -i 's/sgx.enclave_size = "2048M"/sgx.enclave_size = "4G"/g' blender.manifest.template
@@ -205,29 +161,25 @@ stage('test-sgx') {
         sh 'echo "Blender Example Test Failed"'
     }
 
-    try {
+    try{
         timeout(time: 5, unit: 'MINUTES') {
             sh '''
-                cd Examples/r
-                sed -i '/@$(RM) OUTPUT/d' Makefile
-                if [ "${gcc_dump_machine}" == 'x86_64-redhat-linux' ]
-                then
-                    sed -i '$ a loader.pal_internal_mem_size = "128M"' R.manifest.template 
-                fi            
+                cd CI-Examples/sqlite
                 make ${MAKEOPTS} ${ARCH_LIB_OPT} all
-                make ${MAKEOPTS} SGX=1 check
+                make ${MAKEOPTS} SGX=1 regression
             '''
         }
     } catch (Exception e){
         env.build_ok = false
-        sh 'echo "R Example Test Failed"'
+        sh 'echo "SQLite Example Test Failed"'
     }
+
     /*timeout(time: 5, unit: 'MINUTES') {
         sh '''
             # test SGX remote attestation only on Ubuntu 18.04 to keep internet requests to minimum
             .ci/isdistro bionic || exit 0
 
-            cd Examples/ra-tls-mbedtls
+            cd CI-Examples/ra-tls-mbedtls
             if [ "${ra_client_spid}" != "" ] && [ "${ra_client_key}" != "" ]; \
             then \
                 make check_epid RA_CLIENT_SPID=${ra_client_spid} \
@@ -247,7 +199,7 @@ stage('test-sgx') {
             # test SGX remote attestation only on Ubuntu 18.04 to keep internet requests to minimum
             .ci/isdistro bionic || exit 0
 
-            cd Examples/ra-tls-secret-prov
+            cd CI-Examples/ra-tls-secret-prov
             if [ "${ra_client_spid}" != "" ] && [ "${ra_client_key}" != "" ]; \
             then \
                 make SGX=1 check_epid RA_CLIENT_SPID=${ra_client_spid} \

--- a/ci/stage-test-stress-ng.jenkinsfile
+++ b/ci/stage-test-stress-ng.jenkinsfile
@@ -6,7 +6,7 @@ stage('stress-ng') {
                 timeout(time: 240, unit: 'MINUTES') {
                     sh '''
                         export cmd=graphene-direct
-                        cd Examples/stress-ng
+                        cd CI-Examples/stress-ng
                         if test -n "$SGX"
                         then
                             make SGX=1
@@ -32,7 +32,7 @@ stage('stress-ng') {
                 env.build_ok = false
                 sh 'echo "Stress-ng Failed"'
             } finally {
-                archiveArtifacts 'Examples/stress-ng/*.log'
+                archiveArtifacts 'CI-Examples/stress-ng/*.log'
             }
         } else {
             sh 'echo "Ignoring stress-ng run. For enabling pass True from Jenkins build parameters"'

--- a/ci/ubuntu18.04.dockerfile
+++ b/ci/ubuntu18.04.dockerfile
@@ -56,7 +56,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3-pyelftools \
     python3-pytest \
     python3-scipy \
-    r-base-core \
+    sqlite3 \
     shellcheck \
     sudo \
     texinfo \

--- a/ci/ubuntu20.04.dockerfile
+++ b/ci/ubuntu20.04.dockerfile
@@ -58,7 +58,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3-scipy \
     python3-sphinx-rtd-theme \
     python3-toml \
-    r-base-core \
+    sqlite3 \
     shellcheck \
     sphinx-doc \
     texinfo \

--- a/ltp_config/ltp_tests.cfg
+++ b/ltp_config/ltp_tests.cfg
@@ -1007,6 +1007,9 @@ skip = yes
 [mkdir05A]
 skip = yes
 
+[mkdir09]
+skip = yes
+
 [mkdirat02]
 skip = yes
 

--- a/test_workloads.py
+++ b/test_workloads.py
@@ -8,17 +8,12 @@ import os
 
 class Test_Workload_Results():
     def test_bash_workload(self):
-        bash_result_file = open("Examples/bash/OUTPUT", "r")
+        bash_result_file = open("CI-Examples/bash/OUTPUT", "r")
         bash_contents = bash_result_file.read()
         assert("readlink" in bash_contents)
 
-    def test_curl_load(self):
-        curl_result_file = open("Examples/curl/OUTPUT", "r")
-        curl_contents = curl_result_file.read()
-        assert("Hello World" in curl_contents)
-
     def test_python_workload(self):
-        python_result_file = open("Examples/python/TEST_STDOUT", "r")
+        python_result_file = open("CI-Examples/python/TEST_STDOUT", "r")
         python_contents = python_result_file.read()
         assert("Success 1/4" in python_contents)
         assert("Success 2/4" in python_contents)
@@ -26,28 +21,23 @@ class Test_Workload_Results():
         assert("Success 4/4" in python_contents)
 
     def test_lightppd_workload(self):
-        for filename in glob.glob("Examples/lighttpd/result-*"):
+        for filename in glob.glob("CI-Examples/lighttpd/result-*"):
             lightppd_result_file = open(filename,"r")
         lightppd_contents = lightppd_result_file.read()
         assert("0,0" in lightppd_contents)
 
     def test_nginx_workload(self):
-        for filename in glob.glob("Examples/nginx/result-*"):
+        for filename in glob.glob("CI-Examples/nginx/result-*"):
             nginx_result_file = open(filename,"r")
         nginx_contents = nginx_result_file.read()
         assert("0,0" in nginx_contents)
 
     def test_blender(self):
-        blender_result_file = "Examples/blender/data/images/simple_scene.blend0001.png"
+        blender_result_file = "CI-Examples/blender/data/images/simple_scene.blend0001.png"
         assert(path.exists(blender_result_file))
 
-    def test_r_load(self):
-        r_result_file = open("Examples/r/OUTPUT", "r")
-        r_contents = r_result_file.read()
-        assert("success" in r_contents)
-
     def test_redis(self):
-        redis_result_file = open("Examples/redis/OUTPUT", "r")
+        redis_result_file = open("CI-Examples/redis/OUTPUT", "r")
         redis_contents = redis_result_file.read()
         assert(("PING_INLINE" in redis_contents) and ("MSET" in redis_contents))
 


### PR DESCRIPTION
In this commit, "Examples" folder is renamed to CI-Examples.
The examples curl, gcc, apache and R are removed.
SQLite example is added. mkdir09 is skipped in ltp_tests.cfg