### PR TITLE
Skipping the TC "large_mmap" in LibOS for DCAP

### DIFF
--- a/ci/stage-test.jenkinsfile
+++ b/ci/stage-test.jenkinsfile
@@ -40,7 +40,7 @@ stage('test') {
                 if (env.node_label == "graphene_dcap") {
                     sh '''
                         cd LibOS/shim/test/regression
-                        python3 -m pytest -v --junit-xml libos-regression.xml test_libos.py
+                        python3 -m pytest -v -k "not large_mmap" --junit-xml libos-regression.xml test_libos.py
                     '''
                 } else {
                      sh '''


### PR DESCRIPTION
In this commit, the large_mmap TC is skipped as the machine doesn't have sufficient memory.