### PR TITLE
Mounting device "cpu_dma_latency" for docker build

### DIFF
--- a/ci/config-docker.jenkinsfile
+++ b/ci/config-docker.jenkinsfile
@@ -3,6 +3,7 @@ env.PREFIX = '/home/intel/graphene_install/usr'
 // don't mess with PATH before reading this: https://issues.jenkins.io/browse/JENKINS-49076
 env.DOCKER_ARGS_COMMON = """
     --device=/dev/kmsg:/dev/kmsg
+    --device=/dev/cpu_dma_latency:/dev/cpu_dma_latency
     --env=PATH=${env.PREFIX}/bin:${env.PATH}
     --volume=/usr/bin/stress-ng:/usr/bin/stress-ng
 """


### PR DESCRIPTION
In this commit, the cpu_dma_latency is mounted in dockerfile for 5.12 kernel issues