### PR TITLE
Adding sed commands to mount cpu_dmalatency for DCAP

### DIFF
--- a/ci/linux-sgx-ubuntu18.04-gcc-release.jenkinsfile
+++ b/ci/linux-sgx-ubuntu18.04-gcc-release.jenkinsfile
@@ -25,6 +25,12 @@ node (node_label) {
                 $WORKSPACE/LibOS/shim/src/fs/shim_fs.c'
             sh 'sed -i \'s/.release  = "3.10.0"/.release  = "5.10.0"/\' \
                 $WORKSPACE/LibOS/shim/src/sys/shim_uname.c'
+                
+            sh 'sed -i \'48 a fs.mount.dmalatency.type = "chroot"\\n \
+                fs.mount.dmalatency.path="/dev/cpu_dma_latency"\\n \
+                fs.mount.dmalatency.uri="file:/dev/cpu_dma_latency"\\n \
+                \\nsgx.allowed_files.dmalatency="file:/dev/cpu_dma_latency"\\n\' \
+                $WORKSPACE/LibOS/shim/test/ltp/manifest.LTP'                
 
             load '../ci/config-docker.jenkinsfile'
 


### PR DESCRIPTION
In this commit, cpu_dmalatency is mounted for Ubuntu 18.04 on DCAP machine