### PR TITLE
Adding cpu dma latency to 18.04 Native

### DIFF
--- a/ci/linux-direct-ubuntu18.04-gcc-release.jenkinsfile
+++ b/ci/linux-direct-ubuntu18.04-gcc-release.jenkinsfile
@@ -23,6 +23,12 @@ node(node_label) {
                 $WORKSPACE/LibOS/shim/src/fs/shim_fs.c'
             sh 'sed -i \'s/.release  = "3.10.0"/.release  = "5.10.0"/\' \
                 $WORKSPACE/LibOS/shim/src/sys/shim_uname.c'
+                
+            sh 'sed -i \'48 a fs.mount.dmalatency.type = "chroot"\\n \
+                fs.mount.dmalatency.path="/dev/cpu_dma_latency"\\n \
+                fs.mount.dmalatency.uri="file:/dev/cpu_dma_latency"\\n \
+                \\nsgx.allowed_files.dmalatency="file:/dev/cpu_dma_latency"\\n\' \
+                $WORKSPACE/LibOS/shim/test/ltp/manifest.LTP'                
 
             load '../ci/config-docker.jenkinsfile'
 


### PR DESCRIPTION
In this commit, the sed commands to add cpu dma latency are added to 18.04 native configuration for fixing slept too long issue.