### PR TITLE
Archiving meson and ninja logs

### DIFF
--- a/ci/stage-build-nosgx.jenkinsfile
+++ b/ci/stage-build-nosgx.jenkinsfile
@@ -9,12 +9,14 @@ stage('build') {
                         --buildtype="$BUILDTYPE" \
                         -Dskeleton=enabled \
                         -Ddirect=enabled \
-                        -Dsgx=disabled
-                    ninja -vC build
-                    ninja -vC build install
+                        -Dsgx=disabled > meson_cmd_output.txt
+                    ninja -vC build > ninja_build_log.txt
+                    ninja -vC build install > ninja_install_log.txt
                 '''
             } finally {
                 archiveArtifacts 'build/meson-logs/**/*'
+                archiveArtifacts 'ninja_build_log.txt'
+                archiveArtifacts 'ninja_install_log.txt'
             }
 
             // Absolute path to libdir, as configured by Meson.

--- a/ci/stage-build-sgx.jenkinsfile
+++ b/ci/stage-build-sgx.jenkinsfile
@@ -25,12 +25,14 @@ stage('build') {
                         --buildtype="$BUILDTYPE" \
                         -Ddirect=disabled \
                         -Dsgx=enabled \
-                        -Dsgx_driver=oot
-                    ninja -vC build
-                    ninja -vC build install
+                        -Dsgx_driver=oot > meson_cmd_output.txt
+                    ninja -vC build > ninja_build_log.txt
+                    ninja -vC build install > ninja_install_log.txt
                     '''
                 } finally {
                     archiveArtifacts 'build/meson-logs/**/*'
+                    archiveArtifacts 'ninja_build_log.txt'
+                    archiveArtifacts 'ninja_install_log.txt'                    
                 }
 
             } else if (env.node_label == "graphene_dcap") {
@@ -49,12 +51,14 @@ stage('build') {
                         --buildtype="$BUILDTYPE" \
                         -Ddirect=disabled \
                         -Dsgx=enabled \
-                        -Dsgx_driver=dcap1.6
-                    ninja -vC build
-                    ninja -vC build install
+                        -Dsgx_driver=dcap1.6 > meson_cmd_output.txt
+                    ninja -vC build > ninja_build_log.txt
+                    ninja -vC build install > ninja_install_log.txt
                     '''
                 } finally {
                     archiveArtifacts 'build/meson-logs/**/*'
+                    archiveArtifacts 'ninja_build_log.txt'
+                    archiveArtifacts 'ninja_install_log.txt'                       
                 }
 
             } else {
@@ -65,12 +69,14 @@ stage('build') {
                         --prefix="$PREFIX" \
                         --buildtype="$BUILDTYPE" \
                         -Ddirect=disabled \
-                        -Dsgx=enabled
-                    ninja -vC build
-                    ninja -vC build install
+                        -Dsgx=enabled > meson_cmd_output.txt
+                    ninja -vC build > ninja_build_log.txt
+                    ninja -vC build install > ninja_install_log.txt
                 '''
                 } finally {
                     archiveArtifacts 'build/meson-logs/**/*'
+                    archiveArtifacts 'ninja_build_log.txt'
+                    archiveArtifacts 'ninja_install_log.txt'                      
                 }
             }
 


### PR DESCRIPTION
In this commit, the meson and ninja logs are archived to avoid long output logs in console output.