### PR TITLE
Adding conditions for python and memcached example in workload parser

### DIFF
--- a/ci/stage-test-direct.jenkinsfile
+++ b/ci/stage-test-direct.jenkinsfile
@@ -62,7 +62,7 @@ stage('test-direct') {
                     # memcslap populates server but doesn't report errors, use
                     # memcached-tool for this (must return two lines of stats)
                     memcslap --servers=127.0.0.1 --concurrency=8
-                    src/scripts/memcached-tool 127.0.0.1 | wc -l | grep -w "2"
+                    src/scripts/memcached-tool 127.0.0.1 | wc -l | grep -w "2" 2>&1 | tee OUTPUT.txt
                 '''
             }
         } catch (Exception e){

--- a/ci/stage-test-sgx.jenkinsfile
+++ b/ci/stage-test-sgx.jenkinsfile
@@ -28,18 +28,7 @@ stage('test-sgx') {
         }
     }
 
-    try{
-        timeout(time: 5, unit: 'MINUTES') {
-            sh '''
-                cd CI-Examples/python
-                make ${MAKEOPTS} ${ARCH_LIB_OPT} all
-                make ${MAKEOPTS} SGX=1 check
-            '''
-        }
-    } catch (Exception e){
-        env.build_ok = false
-        sh 'echo "Python Example Test Failed"'
-    }
+
 
     try{
         timeout(time: 5, unit: 'MINUTES') {
@@ -67,12 +56,25 @@ stage('test-sgx') {
                     # memcslap populates server but doesn't report errors, use
                     # memcached-tool for this (must return two lines of stats)
                     memcslap --servers=127.0.0.1 --concurrency=8
-                    src/scripts/memcached-tool 127.0.0.1 | wc -l | grep -w "2"
+                    src/scripts/memcached-tool 127.0.0.1 | wc -l | grep -w "2" 2>&1 | tee OUTPUT.txt
                 '''
             }
         } catch (Exception e){
             env.build_ok = false
             sh 'echo "Memcached Example Test Failed"'
+        }
+
+        try{
+            timeout(time: 5, unit: 'MINUTES') {
+                sh '''
+                    cd CI-Examples/python
+                    make ${MAKEOPTS} ${ARCH_LIB_OPT} all
+                    make ${MAKEOPTS} SGX=1 check
+                '''
+            }
+        } catch (Exception e){
+            env.build_ok = false
+            sh 'echo "Python Example Test Failed"'
         }
     }
 

--- a/test_workloads.py
+++ b/test_workloads.py
@@ -4,7 +4,10 @@ import logging
 import glob
 from os import path
 import os
+import pytest
 
+gcc_dumpmachine = os.environ.get('gcc_dump_machine')
+sgx_mode = os.environ.get('SGX')
 
 class Test_Workload_Results():
     def test_bash_workload(self):
@@ -12,6 +15,8 @@ class Test_Workload_Results():
         bash_contents = bash_result_file.read()
         assert("readlink" in bash_contents)
 
+    @pytest.mark.skipif((gcc_dumpmachine == 'x86_64-redhat-linux' and sgx_mode == '1'),
+                    reason="Python Cent/RHEL issue")
     def test_python_workload(self):
         python_result_file = open("CI-Examples/python/TEST_STDOUT", "r")
         python_contents = python_result_file.read()
@@ -20,6 +25,13 @@ class Test_Workload_Results():
         assert("Success 3/4" in python_contents)
         assert("Success 4/4" in python_contents)
 
+    @pytest.mark.skipif(gcc_dumpmachine == 'x86_64-redhat-linux',
+                    reason="Memcached libraries not available for CENT/RHEL")
+    def test_memcached_workload(self):
+        memcached_result_file = open("CI-Examples/memcached/OUTPUT.txt", "r")
+        memcached_contents = memcached_result_file.read()
+        assert("2" in memcached_contents)
+        
     def test_lightppd_workload(self):
         for filename in glob.glob("CI-Examples/lighttpd/result-*"):
             lightppd_result_file = open(filename,"r")


### PR DESCRIPTION
In this commit, the python example is skipped by workload parser for CENT/RHEL machines with SGX mode.
The memcached example is added to parser and skipped for CENT/RHEL.