### PR TITLE
Adding sandstone to workload parser

### DIFF
--- a/ci/linux-sgx-centos8.2-gcc-release.jenkinsfile
+++ b/ci/linux-sgx-centos8.2-gcc-release.jenkinsfile
@@ -44,7 +44,6 @@ node (node_label) {
             load '../ci/stage-build-sgx.jenkinsfile'
             load '../ci/stage-test.jenkinsfile'
             load '../ci/stage-test-sgx.jenkinsfile'
-            load '../ci/stage-test-sandstone.jenkinsfile'
             load '../ci/stage-test-stress-ng.jenkinsfile'
         }
     } finally {

--- a/ci/linux-sgx-ubuntu18.04-gcc-release.jenkinsfile
+++ b/ci/linux-sgx-ubuntu18.04-gcc-release.jenkinsfile
@@ -44,7 +44,6 @@ node (node_label) {
                 load '../ci/stage-build-sgx.jenkinsfile'
                 load '../ci/stage-test.jenkinsfile'
                 load '../ci/stage-test-sgx.jenkinsfile'
-                load '../ci/stage-test-sandstone.jenkinsfile'
                 load '../ci/stage-test-stress-ng.jenkinsfile'
             }
         }

--- a/ci/linux-sgx-ubuntu20.04-gcc-release.jenkinsfile
+++ b/ci/linux-sgx-ubuntu20.04-gcc-release.jenkinsfile
@@ -43,7 +43,6 @@ node(node_label) {
                 load '../ci/stage-build-sgx.jenkinsfile'
                 load '../ci/stage-test.jenkinsfile'
                 load '../ci/stage-test-sgx.jenkinsfile'
-                load '../ci/stage-test-sandstone.jenkinsfile'
                 load '../ci/stage-test-stress-ng.jenkinsfile'
             }
         }

--- a/ci/stage-test-sandstone.jenkinsfile
+++ b/ci/stage-test-sandstone.jenkinsfile
@@ -8,7 +8,7 @@ stage('test') {
                 if test -n "$SGX"
                 then
                     make SGX=1 
-                    SGX=1 make start-sandstone
+                    SGX=1 make start-sandstone 2>&1 | tee OUTPUT.txt
                 fi
             fi
         '''

--- a/ci/stage-test-sgx.jenkinsfile
+++ b/ci/stage-test-sgx.jenkinsfile
@@ -216,6 +216,22 @@ stage('test-sgx') {
         '''
     }*/
 
+    try{
+        timeout(time: 90, unit: 'MINUTES') {
+            sh '''
+                if [ "${no_cpu}" -gt 16 ]
+                then
+                    cd CI-Examples/sandstone-50-bin
+                    make SGX=1 
+                    SGX=1 make start-sandstone 2>&1 | tee OUTPUT.txt
+                fi
+            '''
+        }
+    } catch (Exception e) {
+        env.build_ok = false
+        sh 'echo "Sandstone workload Failed"'
+    }
+
     try {
         timeout(time: 2, unit: 'MINUTES') {
             sh 'python3 -m pytest -v --junit-xml workload-regression.xml test_workloads.py'

--- a/test_workloads.py
+++ b/test_workloads.py
@@ -8,6 +8,7 @@ import pytest
 
 gcc_dumpmachine = os.environ.get('gcc_dump_machine')
 sgx_mode = os.environ.get('SGX')
+no_cores = os.environ.get('no_cpu')
 
 class Test_Workload_Results():
     def test_bash_workload(self):
@@ -60,4 +61,10 @@ class Test_Workload_Results():
                 and ("row 3" in sqlite_contents) \
                 and ("row 2" in sqlite_contents) \
                 and ("row 1" in sqlite_contents))
-
+    
+    @pytest.mark.skipif((int(no_cores) < 16 or sgx_mode != '1'),
+                    reason="Sandstone is enabled on servers with SGX")
+    def test_sandstone_workload(self):
+        sandstone_result_file = open("CI-Examples/sandstone-50-bin/OUTPUT.txt", "r")
+        sandstone_contents = sandstone_result_file.read()
+        assert(("Loop iteration 1 finished" in sandstone_contents) and ("exit: pass" in sandstone_contents))


### PR DESCRIPTION
In this commit, sandstone is enabled on workload parser for servers with SGX mode.