### PR TITLE
Fixing workload parser for Native

### DIFF
--- a/ci/stage-test-direct.jenkinsfile
+++ b/ci/stage-test-direct.jenkinsfile
@@ -1,4 +1,5 @@
 stage('test-direct') {
+    env.no_cpu = sh(script:'nproc', returnStdout: true).trim()
     try {
         timeout(time: 30, unit: 'MINUTES') {
             sh '''


### PR DESCRIPTION
In this commit, the number of cores which is required for skipping sandstone testing for Native mode is added