### PR TITLE
Adding run testcases to LTP

### DIFF
--- a/ltp_config/ltp_tests.cfg
+++ b/ltp_config/ltp_tests.cfg
@@ -15,6 +15,10 @@ timeout = 30
 [accept02]
 skip = yes
 
+# utimensat
+[access01_run]
+skip = yes
+
 # tmpfs
 [access04]
 skip = yes
@@ -83,6 +87,9 @@ skip = yes
 [chmod01A]
 skip = yes
 
+#[chmod02]
+#timeout = 40
+
 # getgrnam("bin") fails with ENOENT
 [chmod05]
 skip = yes
@@ -103,12 +110,12 @@ skip = yes
 [chroot01]
 skip = yes
 
-#[chroot03_run]
-#must-pass =
-#    1
-#    2
-#    3
-#    4
+[chroot03_run]
+must-pass =
+    1
+    2
+    3
+    4
 
 # hangs, no setuid(), rmdir() failing
 [chroot04]
@@ -131,8 +138,6 @@ must-pass =
     3
     4
     5
-    6
-    7
     8
     9
     11
@@ -341,6 +346,15 @@ skip = yes
 [fchown05*]
 skip = yes
 
+[fchownat01_run]
+must-pass =
+    1
+    2
+    3
+    5
+
+[fchownat02_run]
+skip = yes
 
 [fcntl01*]
 skip = yes
@@ -626,10 +640,19 @@ must-pass =
 [getcpu01]
 skip = yes
 
+[getcwd03_run]
+skip = yes
+
 # utimensat
 [getcwd04]
 must-pass =
     2
+
+#[getdents01_run]
+#skip = yes
+
+#[getdents01_run_64]
+#skip = yes
 
 # tries to open /etc/hosts
 [getdtablesize01]
@@ -894,6 +917,18 @@ must-pass =
 skip = yes
 
 [lseek11]
+skip = yes
+
+[lstat01A]
+skip = yes
+
+[lstat01A_64]
+skip = yes
+
+[lstat01_run]
+skip = yes
+
+[lstat01_run_64]
 skip = yes
 
 [lstat02]
@@ -1216,6 +1251,10 @@ skip = yes
 [open06]
 skip = yes
 
+# Requires symlink() support
+[open07_run]
+skip = yes
+
 # Subtest 5 requires proper file permissions checks (file with 0600 is opened using another user and
 # failure is expected).
 [open08]
@@ -1232,6 +1271,9 @@ skip = yes
 
 # Uses /proc/mounts
 [open12]
+skip = yes
+
+[open13_run]
 skip = yes
 
 # Requires O_TMPFILE support
@@ -1494,6 +1536,9 @@ must-pass =
 [quotactl*]
 skip = yes
 
+[read03_run]
+skip = yes
+
 [readahead01]
 skip = yes
 
@@ -1506,8 +1551,19 @@ timeout = 40
 [readdir21]
 skip = yes
 
+[readlink01A]
+skip = yes
+
+[readlink01_run]
+skip = yes
+
 [readlink03]
 skip = yes
+
+[readlinkat01_run]
+must-pass =
+    3
+    4
 
 [realpath01]
 skip = yes
@@ -1564,6 +1620,15 @@ skip = yes
 [removexattr02]
 skip = yes
 
+[rename01A]
+skip = yes
+
+[rename01_run]
+skip = yes
+
+[rename03_run]
+skip = yes
+
 [rename04]
 skip = yes
 
@@ -1583,6 +1648,9 @@ skip = yes
 skip = yes
 
 [rename12]
+skip = yes
+
+[rename13_run]
 skip = yes
 
 [renameat01]
@@ -2079,9 +2147,37 @@ skip = yes
 [stat04_64]
 skip = yes
 
+# no symlink()
+[statfs02_run]
+must-pass =
+    1
+    2
+    3
+    4
+    5
+
+# no symlink()
+[statfs02_run_64]
+must-pass =
+    1
+    2
+    3
+    4
+    5
+
+[statfs03]
+skip = yes
+
 [statfs03_64]
 skip = yes
 
+# no symlink()
+[statvfs02_run]
+must-pass =
+    1
+    3
+    4
+    5
 
 [statx01]
 skip = yes
@@ -2296,6 +2392,12 @@ must-pass =
 [unlink01]
 skip = yes
 
+[unlink05_run]
+must-pass = 
+    1
+
+[unlink08_run]
+skip = yes
 
 [unshare01]
 skip = yes

--- a/ltp_src/runtest/syscalls-new
+++ b/ltp_src/runtest/syscalls-new
@@ -6,7 +6,7 @@ accept02 accept02
 
 accept4_01 accept4_01
 
-#access01_run access01_run
+access01_run access01_run
 access03 access03
 access04 access04
 
@@ -80,7 +80,7 @@ chown05_16 chown05_16
 
 chroot01 chroot01
 chroot02 chroot02
-#chroot03_run chroot03_run
+chroot03_run chroot03_run
 chroot04 chroot04
 
 clock_adjtime01 clock_adjtime01
@@ -238,8 +238,8 @@ fchown05 fchown05
 fchown05_16 fchown05_16
 
 #fchownat test case
-#fchownat01_run fchownat01_run
-#fchownat02_run fchownat02_run
+fchownat01_run fchownat01_run
+fchownat02_run fchownat02_run
 
 fcntl01 fcntl01
 fcntl01_64 fcntl01_64
@@ -402,11 +402,11 @@ getcpu01 getcpu01
 
 getcwd01 getcwd01
 getcwd02 getcwd02
-#getcwd03_run getcwd03_run
+getcwd03_run getcwd03_run
 getcwd04 getcwd04
 
 #getdents01_run getdents01_run
-getdents02 getdents02
+#getdents02 getdents02
 
 #getdents01_run_64 getdents01_run -l
 #getdents02_64 getdents02 -l
@@ -670,10 +670,10 @@ lseek02 lseek02
 lseek07 lseek07
 lseek11 lseek11
 
-#lstat01A symlink01 -T lstat01_run
-#lstat01A_64 symlink01 -T lstat01_run_64
-#lstat01_run lstat01_run
-#lstat01_run_64 lstat01_run_64
+lstat01A symlink01 -T lstat01_run
+lstat01A_64 symlink01 -T lstat01_run_64
+lstat01_run lstat01_run
+lstat01_run_64 lstat01_run_64
 lstat02 lstat02
 lstat02_64 lstat02_64
 
@@ -858,12 +858,12 @@ open03 open03
 open04 open04
 open05 open05
 open06 open06
-#open07_run open07_run
+open07_run open07_run
 open08 open08
 open09 open09
 open10 open10
 open12 open12
-#open13_run open13_run
+open13_run open13_run
 open14 open14
 
 #openat test cases
@@ -1025,7 +1025,7 @@ quotactl07 quotactl07
 
 read01 read01
 read02 read02
-#read03_run read03_run
+read03_run read03_run
 read04 read04
 
 readahead01 readahead01
@@ -1034,13 +1034,13 @@ readahead02 readahead02
 readdir01 readdir01
 readdir21 readdir21
 
-#readlink01A symlink01 -T readlink01_run
-#readlink01_run readlink01_run
+readlink01A symlink01 -T readlink01_run
+readlink01_run readlink01_run
 readlink03 readlink03
 
 #readlinkat test cases
-#readlinkat01_run readlinkat01_run
-#readlinkat02_run readlinkat02_run
+readlinkat01_run readlinkat01_run
+readlinkat02_run readlinkat02_run
 
 readv01 readv01
 readv02 readv02
@@ -1065,20 +1065,20 @@ remap_file_pages02 remap_file_pages02
 removexattr01 removexattr01
 removexattr02 removexattr02
 
-#rename01_run rename01_run
-#rename01A symlink01 -T rename01_run
-#rename02_run rename02_run
-#rename03_run rename03_run
+rename01_run rename01_run
+rename01A symlink01 -T rename01_run
+rename02_run rename02_run
+rename03_run rename03_run
 rename04 rename04
 rename05 rename05
 rename06 rename06
 rename07 rename07
-#rename08_run rename08_run
+rename08_run rename08_run
 rename09 rename09
-#rename10_run rename10_run
+rename10_run rename10_run
 rename11 rename11
 rename12 rename12
-#rename13_run rename13_run
+rename13_run rename13_run
 rename14 rename14
 
 #renameat test cases
@@ -1437,13 +1437,13 @@ stat04_64 symlink01 -T stat04_64
 
 statfs01 statfs01
 statfs01_64 statfs01_64
-#statfs02_run statfs02_run
-#statfs02_run_64 statfs02_run_64
+statfs02_run statfs02_run
+statfs02_run_64 statfs02_run_64
 statfs03 statfs03
 statfs03_64 statfs03_64
 
 statvfs01 statvfs01
-#statvfs02_run statvfs02_run
+statvfs02_run statvfs02_run
 
 stime01 stime01
 stime02 stime02
@@ -1570,9 +1570,9 @@ uname02 uname02
 uname04 uname04
 
 unlink01 symlink01 -T unlink01
-#unlink05_run unlink05_run
-#unlink07_run unlink07_run
-#unlink08_run unlink08_run
+unlink05_run unlink05_run
+unlink07_run unlink07_run
+unlink08_run unlink08_run
 
 #unlinkat test cases
 unlinkat01 unlinkat01

--- a/ltp_src/testcases/kernel/syscalls/access/access01_run.c
+++ b/ltp_src/testcases/kernel/syscalls/access/access01_run.c
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) 2000 Silicon Graphics, Inc.  All Rights Reserved.
+ *   AUTHOR		: William Roske
+ */
+/*
+ * Basic test for access(2) using F_OK, R_OK, W_OK and X_OK
+ */
+#include <errno.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include "tst_test.h"
+
+#define FNAME_RWX "/tmp/accessfile_rwx"
+#define FNAME_R   "/tmp/accessfile_r"
+#define FNAME_W   "/tmp/accessfile_w"
+#define FNAME_X   "/tmp/accessfile_x"
+
+#define DFNAME_RWX "accessfile_rwx"
+#define DFNAME_R   "accessfile_r"
+#define DFNAME_W   "accessfile_w"
+#define DFNAME_X   "accessfile_x"
+
+#define DNAME_R   "/tmp/accessdir_r"
+#define DNAME_W   "/tmp/accessdir_w"
+#define DNAME_X   "/tmp/accessdir_x"
+#define DNAME_RW  "/tmp/accessdir_rw"
+#define DNAME_RX  "/tmp/accessdir_rx"
+#define DNAME_WX  "/tmp/accessdir_wx"
+
+static uid_t uid;
+
+static struct tcase {
+	const char *fname;
+	int mode;
+	char *name;
+	int exp_errno;
+	/* 1: nobody expected  2: root expected 3: both */
+	int exp_user;
+} tcases[] = {
+	{FNAME_RWX, F_OK, "F_OK", 0, 3},
+	{FNAME_RWX, X_OK, "X_OK", 0, 3},
+	{FNAME_RWX, W_OK, "W_OK", 0, 3},
+	{FNAME_RWX, R_OK, "R_OK", 0, 3},
+
+	{FNAME_RWX, R_OK|W_OK, "R_OK|W_OK", 0, 3},
+	{FNAME_RWX, R_OK|X_OK, "R_OK|X_OK", 0, 3},
+	{FNAME_RWX, W_OK|X_OK, "W_OK|X_OK", 0, 3},
+	{FNAME_RWX, R_OK|W_OK|X_OK, "R_OK|W_OK|X_OK", 0, 3},
+
+	{FNAME_X, X_OK, "X_OK", 0, 3},
+	{FNAME_W, W_OK, "W_OK", 0, 3},
+	{FNAME_R, R_OK, "R_OK", 0, 3},
+
+	{FNAME_R, X_OK, "X_OK", EACCES, 3},
+	{FNAME_R, W_OK, "W_OK", EACCES, 1},
+	{FNAME_W, R_OK, "R_OK", EACCES, 1},
+	{FNAME_W, X_OK, "X_OK", EACCES, 3},
+	{FNAME_X, R_OK, "R_OK", EACCES, 1},
+	{FNAME_X, W_OK, "W_OK", EACCES, 1},
+
+	{FNAME_R, W_OK|X_OK, "W_OK|X_OK", EACCES, 3},
+	{FNAME_R, R_OK|X_OK, "R_OK|X_OK", EACCES, 3},
+	{FNAME_R, R_OK|W_OK, "R_OK|W_OK", EACCES, 1},
+	{FNAME_R, R_OK|W_OK|X_OK, "R_OK|W_OK|X_OK", EACCES, 3},
+
+	{FNAME_W, W_OK|X_OK, "W_OK|X_OK", EACCES, 3},
+	{FNAME_W, R_OK|X_OK, "R_OK|X_OK", EACCES, 3},
+	{FNAME_W, R_OK|W_OK, "R_OK|W_OK", EACCES, 1},
+	{FNAME_W, R_OK|W_OK|X_OK, "R_OK|W_OK|X_OK", EACCES, 3},
+
+	{FNAME_X, W_OK|X_OK, "W_OK|X_OK", EACCES, 1},
+	{FNAME_X, R_OK|X_OK, "R_OK|X_OK", EACCES, 1},
+	{FNAME_X, R_OK|W_OK, "R_OK|W_OK", EACCES, 1},
+	{FNAME_X, R_OK|W_OK|X_OK, "R_OK|W_OK|X_OK", EACCES, 1},
+
+	{FNAME_R, W_OK, "W_OK", 0, 2},
+	{FNAME_R, R_OK|W_OK, "R_OK|W_OK", 0, 2},
+
+	{FNAME_W, R_OK, "R_OK", 0, 2},
+	{FNAME_W, R_OK|W_OK, "R_OK|W_OK", 0, 2},
+
+	{FNAME_X, R_OK, "R_OK", 0, 2},
+	{FNAME_X, W_OK, "W_OK", 0, 2},
+	{FNAME_X, R_OK|W_OK, "R_OK|W_OK", 0, 2},
+
+	{DNAME_R"/"DFNAME_R, F_OK, "F_OK", 0, 2},
+	{DNAME_R"/"DFNAME_R, R_OK, "R_OK", 0, 2},
+	{DNAME_R"/"DFNAME_R, W_OK, "W_OK", 0, 2},
+
+	{DNAME_R"/"DFNAME_W, F_OK, "F_OK", 0, 2},
+	{DNAME_R"/"DFNAME_W, R_OK, "R_OK", 0, 2},
+	{DNAME_R"/"DFNAME_W, W_OK, "W_OK", 0, 2},
+
+	{DNAME_R"/"DFNAME_X, F_OK, "F_OK", 0, 2},
+	{DNAME_R"/"DFNAME_X, R_OK, "R_OK", 0, 2},
+	{DNAME_R"/"DFNAME_X, W_OK, "W_OK", 0, 2},
+	{DNAME_R"/"DFNAME_X, X_OK, "X_OK", 0, 2},
+
+	{DNAME_W"/"DFNAME_R, F_OK, "F_OK", 0, 2},
+	{DNAME_W"/"DFNAME_R, R_OK, "R_OK", 0, 2},
+	{DNAME_W"/"DFNAME_R, W_OK, "W_OK", 0, 2},
+
+	{DNAME_W"/"DFNAME_W, F_OK, "F_OK", 0, 2},
+	{DNAME_W"/"DFNAME_W, R_OK, "R_OK", 0, 2},
+	{DNAME_W"/"DFNAME_W, W_OK, "W_OK", 0, 2},
+
+	{DNAME_W"/"DFNAME_X, F_OK, "F_OK", 0, 2},
+	{DNAME_W"/"DFNAME_X, R_OK, "R_OK", 0, 2},
+	{DNAME_W"/"DFNAME_X, W_OK, "W_OK", 0, 2},
+	{DNAME_W"/"DFNAME_X, X_OK, "X_OK", 0, 2},
+
+	{DNAME_X"/"DFNAME_R, F_OK, "F_OK", 0, 3},
+	{DNAME_X"/"DFNAME_R, R_OK, "R_OK", 0, 3},
+	{DNAME_X"/"DFNAME_R, W_OK, "W_OK", 0, 2},
+
+	{DNAME_X"/"DFNAME_W, F_OK, "F_OK", 0, 3},
+	{DNAME_X"/"DFNAME_W, R_OK, "R_OK", 0, 2},
+	{DNAME_X"/"DFNAME_W, W_OK, "W_OK", 0, 3},
+
+	{DNAME_X"/"DFNAME_X, F_OK, "F_OK", 0, 3},
+	{DNAME_X"/"DFNAME_X, R_OK, "R_OK", 0, 2},
+	{DNAME_X"/"DFNAME_X, W_OK, "W_OK", 0, 2},
+	{DNAME_X"/"DFNAME_X, X_OK, "X_OK", 0, 3},
+
+	{DNAME_RW"/"DFNAME_R, F_OK, "F_OK", 0, 2},
+	{DNAME_RW"/"DFNAME_R, R_OK, "R_OK", 0, 2},
+	{DNAME_RW"/"DFNAME_R, W_OK, "W_OK", 0, 2},
+
+	{DNAME_RW"/"DFNAME_W, F_OK, "F_OK", 0, 2},
+	{DNAME_RW"/"DFNAME_W, R_OK, "R_OK", 0, 2},
+	{DNAME_RW"/"DFNAME_W, W_OK, "W_OK", 0, 2},
+
+	{DNAME_RW"/"DFNAME_X, F_OK, "F_OK", 0, 2},
+	{DNAME_RW"/"DFNAME_X, R_OK, "R_OK", 0, 2},
+	{DNAME_RW"/"DFNAME_X, W_OK, "W_OK", 0, 2},
+	{DNAME_RW"/"DFNAME_X, X_OK, "X_OK", 0, 2},
+
+	{DNAME_RX"/"DFNAME_R, F_OK, "F_OK", 0, 3},
+	{DNAME_RX"/"DFNAME_R, R_OK, "R_OK", 0, 3},
+	{DNAME_RX"/"DFNAME_R, W_OK, "W_OK", 0, 2},
+
+	{DNAME_RX"/"DFNAME_W, F_OK, "F_OK", 0, 3},
+	{DNAME_RX"/"DFNAME_W, R_OK, "R_OK", 0, 2},
+	{DNAME_RX"/"DFNAME_W, W_OK, "W_OK", 0, 3},
+
+	{DNAME_RX"/"DFNAME_X, F_OK, "F_OK", 0, 3},
+	{DNAME_RX"/"DFNAME_X, R_OK, "R_OK", 0, 2},
+	{DNAME_RX"/"DFNAME_X, W_OK, "W_OK", 0, 2},
+	{DNAME_RX"/"DFNAME_X, X_OK, "X_OK", 0, 3},
+
+	{DNAME_WX"/"DFNAME_R, F_OK, "F_OK", 0, 3},
+	{DNAME_WX"/"DFNAME_R, R_OK, "R_OK", 0, 3},
+	{DNAME_WX"/"DFNAME_R, W_OK, "W_OK", 0, 2},
+
+	{DNAME_WX"/"DFNAME_W, F_OK, "F_OK", 0, 3},
+	{DNAME_WX"/"DFNAME_W, R_OK, "R_OK", 0, 2},
+	{DNAME_WX"/"DFNAME_W, W_OK, "W_OK", 0, 3},
+
+	{DNAME_WX"/"DFNAME_X, F_OK, "F_OK", 0, 3},
+	{DNAME_WX"/"DFNAME_X, R_OK, "R_OK", 0, 2},
+	{DNAME_WX"/"DFNAME_X, W_OK, "W_OK", 0, 2},
+	{DNAME_WX"/"DFNAME_X, X_OK, "X_OK", 0, 3},
+
+	{DNAME_R"/"DFNAME_R, F_OK, "F_OK", EACCES, 1},
+	{DNAME_R"/"DFNAME_R, R_OK, "R_OK", EACCES, 1},
+	{DNAME_R"/"DFNAME_R, W_OK, "W_OK", EACCES, 1},
+	{DNAME_R"/"DFNAME_R, X_OK, "X_OK", EACCES, 3},
+
+	{DNAME_R"/"DFNAME_W, F_OK, "F_OK", EACCES, 1},
+	{DNAME_R"/"DFNAME_W, R_OK, "R_OK", EACCES, 1},
+	{DNAME_R"/"DFNAME_W, W_OK, "W_OK", EACCES, 1},
+	{DNAME_R"/"DFNAME_W, X_OK, "X_OK", EACCES, 3},
+
+	{DNAME_R"/"DFNAME_X, F_OK, "F_OK", EACCES, 1},
+	{DNAME_R"/"DFNAME_X, R_OK, "R_OK", EACCES, 1},
+	{DNAME_R"/"DFNAME_X, W_OK, "W_OK", EACCES, 1},
+	{DNAME_R"/"DFNAME_X, X_OK, "X_OK", EACCES, 1},
+
+	{DNAME_W"/"DFNAME_R, F_OK, "F_OK", EACCES, 1},
+	{DNAME_W"/"DFNAME_R, R_OK, "R_OK", EACCES, 1},
+	{DNAME_W"/"DFNAME_R, W_OK, "W_OK", EACCES, 1},
+	{DNAME_W"/"DFNAME_R, X_OK, "X_OK", EACCES, 3},
+
+	{DNAME_W"/"DFNAME_W, F_OK, "F_OK", EACCES, 1},
+	{DNAME_W"/"DFNAME_W, R_OK, "R_OK", EACCES, 1},
+	{DNAME_W"/"DFNAME_W, W_OK, "W_OK", EACCES, 1},
+	{DNAME_W"/"DFNAME_W, X_OK, "X_OK", EACCES, 3},
+
+	{DNAME_W"/"DFNAME_X, F_OK, "F_OK", EACCES, 1},
+	{DNAME_W"/"DFNAME_X, R_OK, "R_OK", EACCES, 1},
+	{DNAME_W"/"DFNAME_X, W_OK, "W_OK", EACCES, 1},
+	{DNAME_W"/"DFNAME_X, X_OK, "X_OK", EACCES, 1},
+
+	{DNAME_X"/"DFNAME_R, W_OK, "W_OK", EACCES, 1},
+	{DNAME_X"/"DFNAME_R, X_OK, "X_OK", EACCES, 3},
+
+	{DNAME_X"/"DFNAME_W, R_OK, "R_OK", EACCES, 1},
+	{DNAME_X"/"DFNAME_W, X_OK, "X_OK", EACCES, 3},
+
+	{DNAME_X"/"DFNAME_X, R_OK, "R_OK", EACCES, 1},
+	{DNAME_X"/"DFNAME_X, W_OK, "W_OK", EACCES, 1},
+
+	{DNAME_RW"/"DFNAME_R, F_OK, "F_OK", EACCES, 1},
+	{DNAME_RW"/"DFNAME_R, R_OK, "R_OK", EACCES, 1},
+	{DNAME_RW"/"DFNAME_R, W_OK, "W_OK", EACCES, 1},
+	{DNAME_RW"/"DFNAME_R, X_OK, "X_OK", EACCES, 3},
+
+	{DNAME_RW"/"DFNAME_W, F_OK, "F_OK", EACCES, 1},
+	{DNAME_RW"/"DFNAME_W, R_OK, "R_OK", EACCES, 1},
+	{DNAME_RW"/"DFNAME_W, W_OK, "W_OK", EACCES, 1},
+	{DNAME_RW"/"DFNAME_W, X_OK, "X_OK", EACCES, 3},
+
+	{DNAME_RW"/"DFNAME_X, F_OK, "F_OK", EACCES, 1},
+	{DNAME_RW"/"DFNAME_X, R_OK, "R_OK", EACCES, 1},
+	{DNAME_RW"/"DFNAME_X, W_OK, "W_OK", EACCES, 1},
+	{DNAME_RW"/"DFNAME_X, X_OK, "X_OK", EACCES, 1},
+
+	{DNAME_RX"/"DFNAME_R, W_OK, "W_OK", EACCES, 1},
+	{DNAME_RX"/"DFNAME_R, X_OK, "X_OK", EACCES, 3},
+
+	{DNAME_RX"/"DFNAME_W, R_OK, "R_OK", EACCES, 1},
+	{DNAME_RX"/"DFNAME_W, X_OK, "X_OK", EACCES, 3},
+
+	{DNAME_RX"/"DFNAME_X, R_OK, "R_OK", EACCES, 1},
+	{DNAME_RX"/"DFNAME_X, W_OK, "W_OK", EACCES, 1},
+
+	{DNAME_WX"/"DFNAME_R, W_OK, "W_OK", EACCES, 1},
+	{DNAME_WX"/"DFNAME_R, X_OK, "X_OK", EACCES, 3},
+
+	{DNAME_WX"/"DFNAME_W, R_OK, "R_OK", EACCES, 1},
+	{DNAME_WX"/"DFNAME_W, X_OK, "X_OK", EACCES, 3},
+
+	{DNAME_WX"/"DFNAME_X, R_OK, "R_OK", EACCES, 1},
+	{DNAME_WX"/"DFNAME_X, W_OK, "W_OK", EACCES, 1}
+};
+
+static void verify_success(struct tcase *tc, const char *user)
+{
+	if (TST_RET == -1) {
+		tst_res(TFAIL | TTERRNO,
+		        "access(%s, %s) as %s failed unexpectedly",
+		        tc->fname, tc->name, user);
+		return;
+	}
+
+	tst_res(TPASS, "access(%s, %s) as %s", tc->fname, tc->name, user);
+}
+
+static void verify_failure(struct tcase *tc, const char *user)
+{
+	if (TST_RET != -1) {
+		tst_res(TFAIL, "access(%s, %s) as %s succeded unexpectedly",
+		        tc->fname, tc->name, user);
+		return;
+	}
+
+	if (TST_ERR != tc->exp_errno) {
+		tst_res(TFAIL | TTERRNO,
+		        "access(%s, %s) as %s should fail with %s",
+		        tc->fname, tc->name, user,
+		        tst_strerrno(tc->exp_errno));
+		return;
+	}
+
+	tst_res(TPASS | TTERRNO, "access(%s, %s) as %s",
+	        tc->fname, tc->name, user);
+}
+
+static void access_test(struct tcase *tc, const char *user)
+{
+	TEST(access(tc->fname, tc->mode));
+
+	if (tc->exp_errno)
+		verify_failure(tc, user);
+	else
+		verify_success(tc, user);
+}
+
+static void verify_access(unsigned int n)
+{
+	struct tcase *tc = tcases + n;
+	pid_t pid;
+
+	if (tc->exp_user & 0x02)
+		access_test(tc, "root");
+
+	if (tc->exp_user & 0x01) {
+		pid = SAFE_FORK();
+		if (pid) {
+			SAFE_WAITPID(pid, NULL, 0);
+		} else {
+			SAFE_SETUID(uid);
+			access_test(tc, "nobody");
+		}
+	}
+}
+
+static void setup(void)
+{
+	struct passwd *pw;
+
+	umask(0022);
+
+	pw = SAFE_GETPWNAM("nobody");
+
+	uid = pw->pw_uid;
+}
+
+static struct tst_test test = {
+	.needs_tmpdir = 1,
+	.needs_root = 1,
+	.forks_child = 1,
+	.setup = setup,
+	.test = verify_access,
+	.tcnt = ARRAY_SIZE(tcases),
+};

--- a/ltp_src/testcases/kernel/syscalls/access/access01_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/access/access01_setup.c
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) 2000 Silicon Graphics, Inc.  All Rights Reserved.
+ *   AUTHOR		: William Roske
+ */
+/*
+ * Basic test for access(2) using F_OK, R_OK, W_OK and X_OK
+ */
+#include <errno.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include "tst_test.h"
+
+#define FNAME_RWX "/tmp/accessfile_rwx"
+#define FNAME_R   "/tmp/accessfile_r"
+#define FNAME_W   "/tmp/accessfile_w"
+#define FNAME_X   "/tmp/accessfile_x"
+
+#define DFNAME_RWX "accessfile_rwx"
+#define DFNAME_R   "accessfile_r"
+#define DFNAME_W   "accessfile_w"
+#define DFNAME_X   "accessfile_x"
+
+#define DNAME_R   "/tmp/accessdir_r"
+#define DNAME_W   "/tmp/accessdir_w"
+#define DNAME_X   "/tmp/accessdir_x"
+#define DNAME_RW  "/tmp/accessdir_rw"
+#define DNAME_RX  "/tmp/accessdir_rx"
+#define DNAME_WX  "/tmp/accessdir_wx"
+
+static uid_t uid;
+
+static struct tcase {
+	const char *fname;
+	int mode;
+	char *name;
+	int exp_errno;
+	/* 1: nobody expected  2: root expected 3: both */
+	int exp_user;
+} tcases[] = {
+	{FNAME_RWX, F_OK, "F_OK", 0, 3},
+};
+
+static void verify_access(unsigned int n)
+{
+    tst_res(TPASS, "No test function defined");
+}
+
+static void setup(void)
+{
+	struct passwd *pw;
+
+	umask(0022);
+
+	pw = SAFE_GETPWNAM("nobody");
+
+	uid = pw->pw_uid;
+
+	SAFE_TOUCH(FNAME_RWX, 0777, NULL);
+	SAFE_TOUCH(FNAME_R, 0444, NULL);
+	SAFE_TOUCH(FNAME_W, 0222, NULL);
+	SAFE_TOUCH(FNAME_X, 0111, NULL);
+
+	SAFE_MKDIR(DNAME_R, 0444);
+	SAFE_MKDIR(DNAME_W, 0222);
+	SAFE_MKDIR(DNAME_X, 0111);
+	SAFE_MKDIR(DNAME_RW, 0666);
+	SAFE_MKDIR(DNAME_RX, 0555);
+	SAFE_MKDIR(DNAME_WX, 0333);
+
+	SAFE_TOUCH(DNAME_R"/"DFNAME_R, 0444, NULL);
+	SAFE_TOUCH(DNAME_R"/"DFNAME_W, 0222, NULL);
+	SAFE_TOUCH(DNAME_R"/"DFNAME_X, 0111, NULL);
+
+	SAFE_TOUCH(DNAME_W"/"DFNAME_R, 0444, NULL);
+	SAFE_TOUCH(DNAME_W"/"DFNAME_W, 0222, NULL);
+	SAFE_TOUCH(DNAME_W"/"DFNAME_X, 0111, NULL);
+
+	SAFE_TOUCH(DNAME_X"/"DFNAME_R, 0444, NULL);
+	SAFE_TOUCH(DNAME_X"/"DFNAME_W, 0222, NULL);
+	SAFE_TOUCH(DNAME_X"/"DFNAME_X, 0111, NULL);
+
+	SAFE_TOUCH(DNAME_RW"/"DFNAME_R, 0444, NULL);
+	SAFE_TOUCH(DNAME_RW"/"DFNAME_W, 0222, NULL);
+	SAFE_TOUCH(DNAME_RW"/"DFNAME_X, 0111, NULL);
+
+	SAFE_TOUCH(DNAME_RX"/"DFNAME_R, 0444, NULL);
+	SAFE_TOUCH(DNAME_RX"/"DFNAME_W, 0222, NULL);
+	SAFE_TOUCH(DNAME_RX"/"DFNAME_X, 0111, NULL);
+
+	SAFE_TOUCH(DNAME_WX"/"DFNAME_R, 0444, NULL);
+	SAFE_TOUCH(DNAME_WX"/"DFNAME_W, 0222, NULL);
+	SAFE_TOUCH(DNAME_WX"/"DFNAME_X, 0111, NULL);
+}
+
+static struct tst_test test = {
+	.needs_tmpdir = 1,
+	.needs_root = 1,
+	.forks_child = 1,
+	.setup = setup,
+	.test = verify_access,
+	.tcnt = ARRAY_SIZE(tcases),
+};

--- a/ltp_src/testcases/kernel/syscalls/access/access02_run.c
+++ b/ltp_src/testcases/kernel/syscalls/access/access02_run.c
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ *   Copyright (c) International Business Machines Corp., 2001
+ */
+
+/*
+ * Test Description:
+ *  Verify that access() succeeds to check the existence or read/write/execute
+ *  permissions on a file if the mode argument passed was F_OK/R_OK/W_OK/X_OK.
+ *
+ *  Also verify that, access() succeeds to test the accessibility of the file
+ *  referred to by symbolic link if the pathname points to a symbolic link.
+ *
+ *  As well as verify that, these test files can be
+ *  stat/read/written/executed indeed as root and nobody respectively.
+ *
+ * Ported to LTP: Wayne Boyer
+ *	06/2016 Modified by Guangwen Feng <fenggw-fnst@cn.fujitsu.com>
+ */
+
+#include <sys/types.h>
+#include <unistd.h>
+#include <errno.h>
+#include <pwd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <paths.h>
+#include "tst_test.h"
+
+#define FNAME_F "/tmp/access02_f"
+#define FNAME_R "/tmp/access02_r"
+#define FNAME_W "/tmp/access02_w"
+#define FNAME_X "/tmp/access02_x"
+#define SNAME_F "/tmp/access02symlink_f"
+#define SNAME_R "/tmp/access02symlink_r"
+#define SNAME_W "/tmp/access02symlink_w"
+#define SNAME_X "/tmp/access02symlink_x"
+
+static uid_t uid;
+
+static struct tcase {
+	const char *pathname;
+	int mode;
+	char *name;
+	const char *targetname;
+} tcases[] = {
+	{FNAME_F, F_OK, "F_OK", FNAME_F},
+	{FNAME_R, R_OK, "R_OK", FNAME_R},
+	{FNAME_W, W_OK, "W_OK", FNAME_W},
+	{FNAME_X, X_OK, "X_OK", FNAME_X},
+	{SNAME_F, F_OK, "F_OK", FNAME_F},
+	{SNAME_R, R_OK, "R_OK", FNAME_R},
+	{SNAME_W, W_OK, "W_OK", FNAME_W},
+	{SNAME_X, X_OK, "X_OK", FNAME_X}
+};
+
+static void access_test(struct tcase *tc, const char *user)
+{
+	struct stat stat_buf;
+	char command[64];
+
+	TEST(access(tc->pathname, tc->mode));
+
+	if (TST_RET == -1) {
+		tst_res(TFAIL | TTERRNO, "access(%s, %s) as %s failed",
+			tc->pathname, tc->name, user);
+		return;
+	}
+
+	switch (tc->mode) {
+	case F_OK:
+		/*
+		 * The specified file(or pointed to by symbolic link)
+		 * exists, attempt to get its status, if successful,
+		 * access() behaviour is correct.
+		 */
+		TEST(stat(tc->targetname, &stat_buf));
+
+		if (TST_RET == -1) {
+			tst_res(TFAIL | TTERRNO, "stat(%s) as %s failed",
+				tc->targetname, user);
+			return;
+		}
+
+		break;
+	case R_OK:
+		/*
+		 * The specified file(or pointed to by symbolic link)
+		 * has read access, attempt to open the file with O_RDONLY,
+		 * if we get a valid fd, access() behaviour is correct.
+		 */
+		TEST(open(tc->targetname, O_RDONLY));
+
+		if (TST_RET == -1) {
+			tst_res(TFAIL | TTERRNO,
+				"open %s with O_RDONLY as %s failed",
+				tc->targetname, user);
+			return;
+		}
+
+		SAFE_CLOSE(TST_RET);
+
+		break;
+	case W_OK:
+		/*
+		 * The specified file(or pointed to by symbolic link)
+		 * has write access, attempt to open the file with O_WRONLY,
+		 * if we get a valid fd, access() behaviour is correct.
+		 */
+		TEST(open(tc->targetname, O_WRONLY));
+
+		if (TST_RET == -1) {
+			tst_res(TFAIL | TTERRNO,
+				"open %s with O_WRONLY as %s failed",
+				tc->targetname, user);
+			return;
+		}
+
+		SAFE_CLOSE(TST_RET);
+
+		break;
+	case X_OK:
+		/*
+		 * The specified file(or pointed to by symbolic link)
+		 * has execute access, attempt to execute the executable
+		 * file, if successful, access() behaviour is correct.
+		 */
+		TEST(system(tc->targetname));
+
+		if (TST_RET != 0) {
+			tst_res(TFAIL | TTERRNO, "execute %s as %s failed",
+				tc->targetname, user);
+			return;
+		}
+
+		break;
+	default:
+		break;
+	}
+
+	tst_res(TPASS, "access(%s, %s) as %s behaviour is correct.",
+		tc->pathname, tc->name, user);
+}
+
+static void verify_access(unsigned int n)
+{
+	struct passwd *pw;
+
+        pw = SAFE_GETPWNAM("nobody");
+
+        uid = pw->pw_uid;
+
+	struct tcase *tc = &tcases[n];
+	pid_t pid;
+
+	/* test as root */
+	access_test(tc, "root");
+
+	/* test as nobody */
+	pid = SAFE_FORK();
+	if (pid) {
+		SAFE_WAITPID(pid, NULL, 0);
+	} else {
+		SAFE_SETUID(uid);
+		access_test(tc, "nobody");
+	}
+}
+
+static void setup(void)
+{
+	struct passwd *pw;
+
+	pw = SAFE_GETPWNAM("nobody");
+
+	uid = pw->pw_uid;
+}
+
+static struct tst_test test = {
+	.tcnt = ARRAY_SIZE(tcases),
+	.needs_tmpdir = 1,
+	.needs_root = 1,
+	.forks_child = 1,
+	.setup = setup,
+	.test = verify_access,
+};

--- a/ltp_src/testcases/kernel/syscalls/access/access02_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/access/access02_setup.c
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ *   Copyright (c) International Business Machines Corp., 2001
+ */
+
+/*
+ * Test Description:
+ *  Verify that access() succeeds to check the existence or read/write/execute
+ *  permissions on a file if the mode argument passed was F_OK/R_OK/W_OK/X_OK.
+ *
+ *  Also verify that, access() succeeds to test the accessibility of the file
+ *  referred to by symbolic link if the pathname points to a symbolic link.
+ *
+ *  As well as verify that, these test files can be
+ *  stat/read/written/executed indeed as root and nobody respectively.
+ *
+ * Ported to LTP: Wayne Boyer
+ *	06/2016 Modified by Guangwen Feng <fenggw-fnst@cn.fujitsu.com>
+ */
+
+#include <sys/types.h>
+#include <unistd.h>
+#include <errno.h>
+#include <pwd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <paths.h>
+#include "tst_test.h"
+
+#define FNAME_F	"/tmp/access02_f"
+#define FNAME_R	"/tmp/access02_r"
+#define FNAME_W	"/tmp/access02_w"
+#define FNAME_X	"/tmp/access02_x"
+#define SNAME_F	"/tmp/access02symlink_f"
+#define SNAME_R	"/tmp/access02symlink_r"
+#define SNAME_W	"/tmp/access02symlink_w"
+#define SNAME_X	"/tmp/access02symlink_x"
+
+static uid_t uid;
+
+static struct tcase {
+	const char *pathname;
+	int mode;
+	char *name;
+	const char *targetname;
+} tcases[] = {
+	{FNAME_F, F_OK, "F_OK", FNAME_F},
+	// {FNAME_R, R_OK, "R_OK", FNAME_R},
+	// {FNAME_W, W_OK, "W_OK", FNAME_W},
+	// {FNAME_X, X_OK, "X_OK", FNAME_X},
+	// {SNAME_F, F_OK, "F_OK", FNAME_F},
+	// {SNAME_R, R_OK, "R_OK", FNAME_R},
+	// {SNAME_W, W_OK, "W_OK", FNAME_W},
+	// {SNAME_X, X_OK, "X_OK", FNAME_X}
+};
+
+static void access_test(struct tcase *tc, const char *user)
+{
+	struct stat stat_buf;
+	char command[64];
+
+	TEST(access(tc->pathname, tc->mode));
+
+	if (TST_RET == -1) {
+		tst_res(TFAIL | TTERRNO, "access(%s, %s) as %s failed",
+			tc->pathname, tc->name, user);
+		return;
+	}
+
+	switch (tc->mode) {
+	case F_OK:
+		/*
+		 * The specified file(or pointed to by symbolic link)
+		 * exists, attempt to get its status, if successful,
+		 * access() behaviour is correct.
+		 */
+		TEST(stat(tc->targetname, &stat_buf));
+
+		if (TST_RET == -1) {
+			tst_res(TFAIL | TTERRNO, "stat(%s) as %s failed",
+				tc->targetname, user);
+			return;
+		}
+
+		break;
+	case R_OK:
+		/*
+		 * The specified file(or pointed to by symbolic link)
+		 * has read access, attempt to open the file with O_RDONLY,
+		 * if we get a valid fd, access() behaviour is correct.
+		 */
+		TEST(open(tc->targetname, O_RDONLY));
+
+		if (TST_RET == -1) {
+			tst_res(TFAIL | TTERRNO,
+				"open %s with O_RDONLY as %s failed",
+				tc->targetname, user);
+			return;
+		}
+
+		SAFE_CLOSE(TST_RET);
+
+		break;
+	case W_OK:
+		/*
+		 * The specified file(or pointed to by symbolic link)
+		 * has write access, attempt to open the file with O_WRONLY,
+		 * if we get a valid fd, access() behaviour is correct.
+		 */
+		TEST(open(tc->targetname, O_WRONLY));
+
+		if (TST_RET == -1) {
+			tst_res(TFAIL | TTERRNO,
+				"open %s with O_WRONLY as %s failed",
+				tc->targetname, user);
+			return;
+		}
+
+		SAFE_CLOSE(TST_RET);
+
+		break;
+	case X_OK:
+		/*
+		 * The specified file(or pointed to by symbolic link)
+		 * has execute access, attempt to execute the executable
+		 * file, if successful, access() behaviour is correct.
+		 */
+		sprintf(command, "./%s", tc->targetname);
+
+		TEST(system(command));
+
+		if (TST_RET != 0) {
+			tst_res(TFAIL | TTERRNO, "execute %s as %s failed",
+				tc->targetname, user);
+			return;
+		}
+
+		break;
+	default:
+		break;
+	}
+
+	tst_res(TPASS, "access(%s, %s) as %s behaviour is correct.",
+		tc->pathname, tc->name, user);
+}
+
+static void verify_access(unsigned int n)
+{
+	tst_res(TPASS, "NO test function here");
+}
+
+static void setup(void)
+{
+	SAFE_TOUCH(FNAME_F, 0000, NULL);
+	SAFE_TOUCH(FNAME_R, 0444, NULL);
+	SAFE_TOUCH(FNAME_W, 0222, NULL);
+	SAFE_TOUCH(FNAME_X, 0555, NULL);
+	SAFE_FILE_PRINTF(FNAME_X, "#!%s\n", _PATH_BSHELL);
+
+	SAFE_SYMLINK(FNAME_F, SNAME_F);
+	SAFE_SYMLINK(FNAME_R, SNAME_R);
+	SAFE_SYMLINK(FNAME_W, SNAME_W);
+	SAFE_SYMLINK(FNAME_X, SNAME_X);
+}
+
+static struct tst_test test = {
+	.tcnt = ARRAY_SIZE(tcases),
+	.needs_tmpdir = 1,
+	.setup = setup,
+	.test = verify_access,
+};

--- a/ltp_src/testcases/kernel/syscalls/chroot/chroot03_run.c
+++ b/ltp_src/testcases/kernel/syscalls/chroot/chroot03_run.c
@@ -1,0 +1,142 @@
+/*
+ *   Copyright (c) International Business Machines  Corp., 2001
+ *
+ *   This program is free software;  you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *   the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program;  if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ *	Testcase to test whether chroot(2) sets errno correctly.
+ *
+ *	1.	Test for ENAMETOOLONG:
+ *		Create a bad directory name with length more than
+ *		VFS_MAXNAMELEN (Linux kernel variable), and pass it as the
+ *		path to chroot(2).
+ *
+ *	2.	Test for ENOENT:
+ *		Attempt to chroot(2) on a non-existent directory
+ *
+ *	3.	Test for ENOTDIR:
+ *		Attempt to chdir(2) on a file.
+ *
+ *	4.	Test for EFAULT:
+ *		The pathname parameter to chroot() points to an invalid address,
+ *		chroot(2) fails with EPERM.
+ *
+ *	5.	Test for ELOOP:
+ *		Too many symbolic links were encountered When resolving the
+ *		pathname parameter.
+ *
+ *	07/2001 Ported by Wayne Boyer
+ */
+
+#include <stdio.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include "test.h"
+#include <fcntl.h>
+#include "safe_macros.h"
+
+char *TCID = "chroot03";
+
+static int fd;
+static char fname[255] = "/tmp/chroot03_file";
+static char nonexistent_dir[100] = "/tmp/chroot03_dir";
+static char bad_dir[] = "/tmp/abcdefghijklmnopqrstmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyz";
+static char symbolic_dir[] = "/tmp/sym_dir1";
+
+struct test_case_t {
+	char *dir;
+	int error;
+} TC[] = {
+	/*
+	 * to test whether chroot() is setting ENAMETOOLONG if the
+	 * pathname is more than VFS_MAXNAMELEN
+	 */
+	{
+	bad_dir, ENAMETOOLONG},
+	    /*
+	     * to test whether chroot() is setting ENOTDIR if the argument
+	     * is not a directory.
+	     */
+	{
+	fname, ENOTDIR},
+	    /*
+	     * to test whether chroot() is setting ENOENT if the directory
+	     * does not exist.
+	     */
+	{
+	nonexistent_dir, ENOENT},
+#if !defined(UCLINUX)
+	    /*
+	     * attempt to chroot to a path pointing to an invalid address
+	     * and expect EFAULT as errno
+	     */
+	{
+	(char *)-1, EFAULT},
+#endif
+	{symbolic_dir, ELOOP}
+};
+
+int TST_TOTAL = ARRAY_SIZE(TC);
+
+static char *bad_addr;
+
+static void setup(void);
+static void cleanup(void);
+
+int main(int ac, char **av)
+{
+	int lc;
+	int i;
+
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	setup();
+
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+		tst_count = 0;
+
+		for (i = 0; i < TST_TOTAL; i++) {
+			TEST(chroot(TC[i].dir));
+
+			if (TEST_RETURN != -1) {
+				tst_resm(TFAIL, "call succeeded unexpectedly");
+				continue;
+			}
+
+			if (TEST_ERRNO == TC[i].error) {
+				tst_resm(TPASS | TTERRNO, "failed as expected");
+			} else {
+				tst_resm(TFAIL | TTERRNO,
+					 "didn't fail as expected (expected errno "
+					 "= %d : %s)",
+					 TC[i].error, strerror(TC[i].error));
+			}
+		}
+	}
+
+	cleanup();
+	tst_exit();
+}
+
+static void setup(void)
+{}
+
+static void cleanup(void)
+{
+	close(fd);
+	tst_rmdir();
+}

--- a/ltp_src/testcases/kernel/syscalls/chroot/chroot03_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/chroot/chroot03_setup.c
@@ -1,0 +1,146 @@
+/*
+ *   Copyright (c) International Business Machines  Corp., 2001
+ *
+ *   This program is free software;  you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *   the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program;  if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ *	Testcase to test whether chroot(2) sets errno correctly.
+ *
+ *	1.	Test for ENAMETOOLONG:
+ *		Create a bad directory name with length more than
+ *		VFS_MAXNAMELEN (Linux kernel variable), and pass it as the
+ *		path to chroot(2).
+ *
+ *	2.	Test for ENOENT:
+ *		Attempt to chroot(2) on a non-existent directory
+ *
+ *	3.	Test for ENOTDIR:
+ *		Attempt to chdir(2) on a file.
+ *
+ *	4.	Test for EFAULT:
+ *		The pathname parameter to chroot() points to an invalid address,
+ *		chroot(2) fails with EPERM.
+ *
+ *	5.	Test for ELOOP:
+ *		Too many symbolic links were encountered When resolving the
+ *		pathname parameter.
+ *
+ *	07/2001 Ported by Wayne Boyer
+ */
+
+#include <stdio.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include "test.h"
+#include <fcntl.h>
+#include "safe_macros.h"
+
+char *TCID = "chroot03";
+
+static int fd;
+static char fname[255] = "/tmp/chroot03_file";
+static char nonexistent_dir[100] = "/tmp/chroot03_dir";
+static char bad_dir[] = "/tmp/abcdefghijklmnopqrstmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyz";
+static char symbolic_dir[] = "/tmp/sym_dir1";
+
+struct test_case_t {
+	char *dir;
+	int error;
+} TC[] = {
+	/*
+	 * to test whether chroot() is setting ENAMETOOLONG if the
+	 * pathname is more than VFS_MAXNAMELEN
+	 */
+	{
+	bad_dir, ENAMETOOLONG},
+	    /*
+	     * to test whether chroot() is setting ENOTDIR if the argument
+	     * is not a directory.
+	     */
+	{
+	fname, ENOTDIR},
+	    /*
+	     * to test whether chroot() is setting ENOENT if the directory
+	     * does not exist.
+	     */
+	{
+	nonexistent_dir, ENOENT},
+#if !defined(UCLINUX)
+	    /*
+	     * attempt to chroot to a path pointing to an invalid address
+	     * and expect EFAULT as errno
+	     */
+	{
+	(char *)-1, EFAULT},
+#endif
+	{symbolic_dir, ELOOP}
+};
+
+int TST_TOTAL = ARRAY_SIZE(TC);
+
+static char *bad_addr;
+
+static void setup(void);
+static void cleanup(void);
+
+int main(int ac, char **av)
+{
+	int lc;
+	int i;
+
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	setup();
+    tst_resm(TINFO, "No test function defined here");
+	cleanup();
+	tst_exit();
+}
+
+static void setup(void)
+{
+	tst_sig(NOFORK, DEF_HANDLER, cleanup);
+	TEST_PAUSE;
+	tst_tmpdir();
+
+	/*
+	 * create a file and use it to test whether chroot() is setting
+	 * ENOTDIR if the argument is not a directory.
+	 */
+	// (void)sprintf(fname, "tfile_%d", getpid());
+	fd = SAFE_CREAT(cleanup, fname, 0777);
+
+#if !defined(UCLINUX)
+	bad_addr = mmap(0, 1, PROT_NONE,
+			MAP_PRIVATE_EXCEPT_UCLINUX | MAP_ANONYMOUS, 0, 0);
+	if (bad_addr == MAP_FAILED)
+		tst_brkm(TBROK, cleanup, "mmap failed");
+
+	TC[3].dir = bad_addr;
+#endif
+	/*
+	 * create two symbolic directory who point to each other to
+	 * test ELOOP.
+	 */
+	SAFE_SYMLINK(cleanup, "/tmp/sym_dir1/", "/tmp/sym_dir2");
+	SAFE_SYMLINK(cleanup, "/tmp/sym_dir2/", "/tmp/sym_dir1");
+}
+
+static void cleanup(void)
+{
+	close(fd);
+	tst_rmdir();
+}

--- a/ltp_src/testcases/kernel/syscalls/fchownat/fchownat01_run.c
+++ b/ltp_src/testcases/kernel/syscalls/fchownat/fchownat01_run.c
@@ -1,0 +1,126 @@
+/*
+ *   Copyright (c) International Business Machines  Corp., 2006
+ *   AUTHOR: Yi Yang <yyangcdl@cn.ibm.com>
+ *
+ *   This program is free software;  you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *   the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program;  if not, write to the Free Software Foundation,
+ *   Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+/*
+ * DESCRIPTION
+ *	This test case will verify basic function of fchownat
+ *	added by kernel 2.6.16 or up.
+ */
+
+#define _GNU_SOURCE
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include <signal.h>
+
+#include "test.h"
+#include "safe_macros.h"
+#include "fchownat.h"
+#include "lapi/fcntl.h"
+
+#define TESTFILE_1	"testfile"
+#define TESTFILE_2	"/tmp/testfile"
+
+static void setup(void);
+static void cleanup(void);
+
+static int dir_fd;
+static int fd;
+static int no_fd = -1;
+static int cu_fd = AT_FDCWD;
+
+static struct test_case_t {
+	int exp_ret;
+	int exp_errno;
+	int flag;
+	int *fds;
+	char *filenames;
+} test_cases[] = {
+	{0, 0, 0, &dir_fd, TESTFILE_2},
+	{-1, ENOTDIR, 0, &fd, TESTFILE_1},
+	{-1, EBADF, 0, &no_fd, TESTFILE_1},
+	{-1, EINVAL, 9999, &dir_fd, TESTFILE_1},
+	{0, 0, 0, &cu_fd, TESTFILE_2},
+};
+
+char *TCID = "fchownat01";
+int TST_TOTAL = ARRAY_SIZE(test_cases);
+static void fchownat_verify(const struct test_case_t *);
+
+int main(int ac, char **av)
+{
+	int lc;
+	int i;
+
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	setup();
+
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+		tst_count = 0;
+		for (i = 0; i < TST_TOTAL; i++)
+			fchownat_verify(&test_cases[i]);
+	}
+
+	cleanup();
+	tst_exit();
+}
+
+static void setup(void)
+{
+    dir_fd = SAFE_OPEN(cleanup, "/tmp/", O_DIRECTORY);
+
+	fd = SAFE_OPEN(cleanup, "/tmp/testfile2", O_CREAT | O_RDWR, 0600);
+}
+
+static void fchownat_verify(const struct test_case_t *test)
+{
+	TEST(fchownat(*(test->fds), test->filenames, geteuid(),
+		      getegid(), test->flag));
+
+	if (TEST_RETURN != test->exp_ret) {
+		tst_resm(TFAIL | TTERRNO,
+			 "fchownat() returned %ld, expected %d, errno=%d",
+			 TEST_RETURN, test->exp_ret, test->exp_errno);
+		return;
+	}
+
+	if (TEST_ERRNO == test->exp_errno) {
+		tst_resm(TPASS | TTERRNO,
+			 "fchownat() returned the expected errno %d: %s",
+			 test->exp_ret, strerror(test->exp_errno));
+	} else {
+		tst_resm(TFAIL | TTERRNO,
+			 "fchownat() failed unexpectedly; expected: %d - %s",
+			 test->exp_errno, strerror(test->exp_errno));
+	}
+}
+
+static void cleanup(void)
+{
+	if (fd > 0)
+		close(fd);
+    
+	if (dir_fd > 0)
+		close(dir_fd);
+}

--- a/ltp_src/testcases/kernel/syscalls/fchownat/fchownat01_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/fchownat/fchownat01_setup.c
@@ -1,0 +1,125 @@
+/*
+ *   Copyright (c) International Business Machines  Corp., 2006
+ *   AUTHOR: Yi Yang <yyangcdl@cn.ibm.com>
+ *
+ *   This program is free software;  you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *   the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program;  if not, write to the Free Software Foundation,
+ *   Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+/*
+ * DESCRIPTION
+ *	This test case will verify basic function of fchownat
+ *	added by kernel 2.6.16 or up.
+ */
+
+#define _GNU_SOURCE
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include <signal.h>
+
+#include "test.h"
+#include "safe_macros.h"
+#include "fchownat.h"
+#include "lapi/fcntl.h"
+
+#define TESTFILE_1	"testfile"
+#define TESTFILE_2	"/tmp/testfile"
+
+static void setup(void);
+static void cleanup(void);
+
+static int dir_fd;
+static int fd;
+static int no_fd = -1;
+static int cu_fd = AT_FDCWD;
+
+static struct test_case_t {
+	int exp_ret;
+	int exp_errno;
+	int flag;
+	int *fds;
+	char *filenames;
+} test_cases[] = {
+	{0, 0, 0, &dir_fd, TESTFILE_2},
+};
+
+char *TCID = "fchownat01";
+int TST_TOTAL = ARRAY_SIZE(test_cases);
+static void fchownat_verify(const struct test_case_t *);
+
+int main(int ac, char **av)
+{
+	int lc;
+	int i;
+
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	setup();
+}
+
+static void setup(void)
+{
+	if ((tst_kvercmp(2, 6, 16)) < 0)
+		tst_brkm(TCONF, NULL, "This test needs kernel 2.6.16 or newer");
+
+	tst_sig(NOFORK, DEF_HANDLER, cleanup);
+
+	TEST_PAUSE;
+
+	tst_tmpdir();
+
+
+	SAFE_TOUCH(cleanup, TESTFILE_1, 0600, NULL);
+    SAFE_TOUCH(cleanup, TESTFILE_2, 0600, NULL);
+
+}
+
+static void fchownat_verify(const struct test_case_t *test)
+{
+	TEST(fchownat(*(test->fds), test->filenames, geteuid(),
+		      getegid(), test->flag));
+
+	if (TEST_RETURN != test->exp_ret) {
+		tst_resm(TFAIL | TTERRNO,
+			 "fchownat() returned %ld, expected %d, errno=%d",
+			 TEST_RETURN, test->exp_ret, test->exp_errno);
+		return;
+	}
+
+	if (TEST_ERRNO == test->exp_errno) {
+		tst_resm(TPASS | TTERRNO,
+			 "fchownat() returned the expected errno %d: %s",
+			 test->exp_ret, strerror(test->exp_errno));
+	} else {
+		tst_resm(TFAIL | TTERRNO,
+			 "fchownat() failed unexpectedly; expected: %d - %s",
+			 test->exp_errno, strerror(test->exp_errno));
+	}
+}
+
+static void cleanup(void)
+{
+	if (fd > 0)
+		close(fd);
+
+	if (dir_fd > 0)
+		close(dir_fd);
+
+	tst_rmdir();
+}

--- a/ltp_src/testcases/kernel/syscalls/fchownat/fchownat02_run.c
+++ b/ltp_src/testcases/kernel/syscalls/fchownat/fchownat02_run.c
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2014 Fujitsu Ltd.
+ * Author: Zeng Linggang <zenglg.jy@cn.fujitsu.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.
+ */
+/*
+ * Test Description:
+ *   Verify that,
+ *   The flag of fchownat() is AT_SYMLINK_NOFOLLOW and the pathname would
+ *   not be dereferenced if the pathname is a symbolic link.
+ */
+
+#define _GNU_SOURCE
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include <signal.h>
+#include "test.h"
+#include "safe_macros.h"
+#include "fchownat.h"
+#include "lapi/fcntl.h"
+
+#define TESTFILE	"/tmp/fchownat02"
+#define TESTFILE_LINK	"/tmp/fchownat02_link"
+
+char *TCID = "fchownat02";
+int TST_TOTAL = 1;
+
+static int dir_fd;
+static uid_t set_uid = 1000;
+static gid_t set_gid = 1000;
+static void setup(void);
+static void cleanup(void);
+static void test_verify(void);
+static void fchownat_verify(void);
+
+int main(int ac, char **av)
+{
+	int lc;
+	int i;
+
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	setup();
+
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+		tst_count = 0;
+		for (i = 0; i < TST_TOTAL; i++)
+			fchownat_verify();
+	}
+
+	cleanup();
+	tst_exit();
+}
+
+static void setup(void)
+{
+	struct stat c_buf, l_buf;
+
+	dir_fd = SAFE_OPEN(cleanup, "/tmp/", O_DIRECTORY);
+
+	SAFE_STAT(cleanup, TESTFILE_LINK, &c_buf);
+
+	SAFE_LSTAT(cleanup, TESTFILE_LINK, &l_buf);
+
+	if (l_buf.st_uid == set_uid || l_buf.st_gid == set_gid) {
+		tst_brkm(TBROK | TERRNO, cleanup,
+			 "link_uid(%d) == set_uid(%d) or link_gid(%d) == "
+			 "set_gid(%d)", l_buf.st_uid, set_uid, l_buf.st_gid,
+			 set_gid);
+	}
+}
+
+static void fchownat_verify(void)
+{
+	TEST(fchownat(dir_fd, TESTFILE_LINK, set_uid, set_gid,
+		      AT_SYMLINK_NOFOLLOW));
+
+	if (TEST_RETURN != 0) {
+		tst_resm(TFAIL | TTERRNO, "fchownat() failed, errno=%d : %s",
+			 TEST_ERRNO, strerror(TEST_ERRNO));
+	} else {
+		test_verify();
+	}
+}
+
+static void test_verify(void)
+{
+	struct stat c_buf, l_buf;
+
+	SAFE_STAT(cleanup, TESTFILE_LINK, &c_buf);
+
+	SAFE_LSTAT(cleanup, TESTFILE_LINK, &l_buf);
+
+	if (c_buf.st_uid != set_uid && l_buf.st_uid == set_uid &&
+	    c_buf.st_gid != set_gid && l_buf.st_gid == set_gid) {
+		tst_resm(TPASS, "fchownat() test AT_SYMLINK_NOFOLLOW success");
+	} else {
+		tst_resm(TFAIL,
+			 "fchownat() test AT_SYMLINK_NOFOLLOW fail with uid=%d "
+			 "link_uid=%d set_uid=%d | gid=%d link_gid=%d "
+			 "set_gid=%d", c_buf.st_uid, l_buf.st_uid, set_uid,
+			 c_buf.st_gid, l_buf.st_gid, set_gid);
+	}
+}
+
+static void cleanup(void)
+{}

--- a/ltp_src/testcases/kernel/syscalls/fchownat/fchownat02_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/fchownat/fchownat02_setup.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2014 Fujitsu Ltd.
+ * Author: Zeng Linggang <zenglg.jy@cn.fujitsu.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.
+ */
+/*
+ * Test Description:
+ *   Verify that,
+ *   The flag of fchownat() is AT_SYMLINK_NOFOLLOW and the pathname would
+ *   not be dereferenced if the pathname is a symbolic link.
+ */
+
+#define _GNU_SOURCE
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include <signal.h>
+#include "test.h"
+#include "safe_macros.h"
+#include "fchownat.h"
+#include "lapi/fcntl.h"
+
+#define TESTFILE	"/tmp/fchownat02"
+#define TESTFILE_LINK	"/tmp/fchownat02_link"
+
+char *TCID = "fchownat02";
+int TST_TOTAL = 1;
+
+static int dir_fd;
+static uid_t set_uid = 1000;
+static gid_t set_gid = 1000;
+static void setup(void);
+static void cleanup(void);
+static void test_verify(void);
+static void fchownat_verify(void);
+
+int main(int ac, char **av)
+{
+	int lc;
+	int i;
+
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	setup();
+}
+
+static void setup(void)
+{
+	struct stat c_buf, l_buf;
+
+	if ((tst_kvercmp(2, 6, 16)) < 0)
+		tst_brkm(TCONF, NULL, "This test needs kernel 2.6.16 or newer");
+
+	tst_require_root();
+
+	tst_sig(NOFORK, DEF_HANDLER, cleanup);
+
+	TEST_PAUSE;
+
+	tst_tmpdir();
+
+	SAFE_TOUCH(cleanup, TESTFILE, 0600, NULL);
+
+	SAFE_SYMLINK(cleanup, TESTFILE, TESTFILE_LINK);
+}
+
+static void fchownat_verify(void)
+{
+	TEST(fchownat(dir_fd, TESTFILE_LINK, set_uid, set_gid,
+		      AT_SYMLINK_NOFOLLOW));
+
+	if (TEST_RETURN != 0) {
+		tst_resm(TFAIL | TTERRNO, "fchownat() failed, errno=%d : %s",
+			 TEST_ERRNO, strerror(TEST_ERRNO));
+	} else {
+		test_verify();
+	}
+}
+
+static void test_verify(void)
+{
+	struct stat c_buf, l_buf;
+
+	SAFE_STAT(cleanup, TESTFILE_LINK, &c_buf);
+
+	SAFE_LSTAT(cleanup, TESTFILE_LINK, &l_buf);
+
+	if (c_buf.st_uid != set_uid && l_buf.st_uid == set_uid &&
+	    c_buf.st_gid != set_gid && l_buf.st_gid == set_gid) {
+		tst_resm(TPASS, "fchownat() test AT_SYMLINK_NOFOLLOW success");
+	} else {
+		tst_resm(TFAIL,
+			 "fchownat() test AT_SYMLINK_NOFOLLOW fail with uid=%d "
+			 "link_uid=%d set_uid=%d | gid=%d link_gid=%d "
+			 "set_gid=%d", c_buf.st_uid, l_buf.st_uid, set_uid,
+			 c_buf.st_gid, l_buf.st_gid, set_gid);
+	}
+}
+
+static void cleanup(void)
+{
+	tst_rmdir();
+}

--- a/ltp_src/testcases/kernel/syscalls/getcwd/getcwd03_run.c
+++ b/ltp_src/testcases/kernel/syscalls/getcwd/getcwd03_run.c
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) International Business Machines Corp., 2001
+ */
+
+/*
+ * DESCRIPTION
+ * Testcase to check the basic functionality of the getcwd(2)
+ * system call on a symbolic link.
+ *
+ * ALGORITHM
+ * 1) create a directory, and create a symbolic link to it at the
+ *    same directory level.
+ * 2) get the working directory of a directory, and its pathname.
+ * 3) get the working directory of a symbolic link, and its pathname,
+ *    and its readlink info.
+ * 4) compare the working directories and link information.
+ */
+
+#define _GNU_SOURCE 1
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <stdlib.h>
+#include "tst_test.h"
+
+static char dir[BUFSIZ] = "/tmp/getcwd03_dir";
+static char dir_link[BUFSIZ] = "/tmp/getcwd03_symlink";
+
+static void verify_getcwd(void)
+{
+	char link[BUFSIZ];
+	char *res1 = NULL;
+	char *res2 = NULL;
+
+	SAFE_CHDIR(dir);
+
+	res1 = getcwd(NULL, 0);
+	tst_res(TINFO, "res1 is: %s", res1);
+	if (!res1) {
+		tst_res(TFAIL | TERRNO, "getcwd() failed to "
+			"get working directory of a directory");
+		goto end;
+	}
+
+	SAFE_CHDIR("/");
+	SAFE_CHDIR(dir_link);
+
+	res2 = getcwd(NULL, 0);
+	tst_res(TINFO, "res2 is: %s", res2);
+	if (!res2) {
+		tst_res(TFAIL | TERRNO, "getcwd() failed to get "
+			"working directory of a symbolic link");
+		goto end;
+	}
+
+	if (strcmp(res1, res2)) {
+		tst_res(TFAIL,
+			"getcwd() got mismatched working directories (%s, %s)",
+			res1, res2);
+		goto end;
+	}
+
+	SAFE_CHDIR("/");
+	SAFE_READLINK(dir_link, link, sizeof(link));
+	// tst_res(TINFO, "link is: %s", link);
+	// tst_res(TINFO, "SAFE_BASENAME(res1) is: %s", SAFE_BASENAME(res1));
+	// tst_res(TINFO, "res1 is: %s", res1);
+
+	if (strcmp(link, res1)) {
+		tst_res(TFAIL,
+			"link information didn't match the working directory");
+		goto end;
+	}
+
+	tst_res(TPASS, "getcwd() succeeded on a symbolic link");
+
+end:
+	free(res1);
+	free(res2);
+}
+
+static void setup(void)
+{
+	// sprintf(dir, "getcwd1.%d", getpid());
+	// sprintf(dir_link, "getcwd2.%d", getpid());
+// 	SAFE_MKDIR(dir, 0755);
+// 	SAFE_SYMLINK(dir, dir_link);
+ }
+
+static struct tst_test test = {
+	.needs_tmpdir = 1,
+	.setup = setup,
+	.test_all = verify_getcwd
+};

--- a/ltp_src/testcases/kernel/syscalls/getcwd/getcwd03_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/getcwd/getcwd03_setup.c
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) International Business Machines Corp., 2001
+ */
+
+/*
+ * DESCRIPTION
+ * Testcase to check the basic functionality of the getcwd(2)
+ * system call on a symbolic link.
+ *
+ * ALGORITHM
+ * 1) create a directory, and create a symbolic link to it at the
+ *    same directory level.
+ * 2) get the working directory of a directory, and its pathname.
+ * 3) get the working directory of a symbolic link, and its pathname,
+ *    and its readlink info.
+ * 4) compare the working directories and link information.
+ */
+
+#define _GNU_SOURCE 1
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <stdlib.h>
+#include "tst_test.h"
+
+static char dir[BUFSIZ] = "/tmp/getcwd03_dir";
+static char dir_link[BUFSIZ] = "/tmp/getcwd03_symlink";
+
+static void verify_getcwd(void)
+{
+    tst_res(TPASS, "No test function defined");
+// 	char link[BUFSIZ];
+// 	char *res1 = NULL;
+// 	char *res2 = NULL;
+
+// 	SAFE_CHDIR(dir);
+
+// 	res1 = getcwd(NULL, 0);
+// 	if (!res1) {
+// 		tst_res(TFAIL | TERRNO, "getcwd() failed to "
+// 			"get working directory of a directory");
+// 		goto end;
+// 	}
+
+// 	SAFE_CHDIR("..");
+// 	SAFE_CHDIR(dir_link);
+
+// 	res2 = getcwd(NULL, 0);
+// 	if (!res2) {
+// 		tst_res(TFAIL | TERRNO, "getcwd() failed to get "
+// 			"working directory of a symbolic link");
+// 		goto end;
+// 	}
+
+// 	if (strcmp(res1, res2)) {
+// 		tst_res(TFAIL,
+// 			"getcwd() got mismatched working directories (%s, %s)",
+// 			res1, res2);
+// 		goto end;
+// 	}
+
+// 	SAFE_CHDIR("..");
+// 	SAFE_READLINK(dir_link, link, sizeof(link));
+
+// 	if (strcmp(link, SAFE_BASENAME(res1))) {
+// 		tst_res(TFAIL,
+// 			"link information didn't match the working directory");
+// 		goto end;
+// 	}
+
+// 	tst_res(TPASS, "getcwd() succeeded on a symbolic link");
+
+// end:
+// 	free(res1);
+// 	free(res2);
+}
+
+static void setup(void)
+{
+	// sprintf(dir, "getcwd1.%d", getpid());
+	// sprintf(dir_link, "getcwd2.%d", getpid());
+	SAFE_MKDIR(dir, 0755);
+	SAFE_SYMLINK(dir, dir_link);
+}
+
+static struct tst_test test = {
+	.needs_tmpdir = 1,
+	.setup = setup,
+	.test_all = verify_getcwd
+};

--- a/ltp_src/testcases/kernel/syscalls/lstat/lstat01_run.c
+++ b/ltp_src/testcases/kernel/syscalls/lstat/lstat01_run.c
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (c) 2000 Silicon Graphics, Inc.  All Rights Reserved.
+ *  Authors:	William Roske, Dave Fenner
+ *
+ *  06/2019 Ported to new library:
+ *		Christian Amann <camann@suse.com>
+ */
+/*
+ * Basic test for lstat():
+ *
+ * Tests if lstat() writes correct information about a symlink
+ * into the stat structure.
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include "tst_test.h"
+
+#define TESTFILE        "/tmp/tst_file"
+#define TESTSYML        "/tmp/tst_syml"
+
+static uid_t user_id;
+static gid_t group_id;
+
+static void run(void)
+{
+	struct stat stat_buf;
+
+	memset(&stat_buf, 0, sizeof(stat_buf));
+
+	TEST(lstat(TESTSYML, &stat_buf));
+	if (TST_RET == -1)
+		tst_res(TFAIL | TTERRNO, "Calling lstat() failed");
+
+	if ((stat_buf.st_mode & S_IFMT) != S_IFLNK ||
+	    stat_buf.st_uid != user_id ||
+	    stat_buf.st_gid != group_id ||
+	    stat_buf.st_size != strlen(TESTFILE)) {
+		tst_res(TFAIL,
+			"lstat() reported incorrect values for the symlink!");
+	} else {
+		tst_res(TPASS,
+			"lstat() reported correct values for the symlink!");
+	}
+}
+
+static void setup(void)
+{
+	
+	user_id  = getuid();
+	group_id = getgid();
+}
+
+static void cleanup(void)
+{}
+
+static struct tst_test test = {
+	.test_all = run,
+	.setup = setup,
+};

--- a/ltp_src/testcases/kernel/syscalls/lstat/lstat01_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/lstat/lstat01_setup.c
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (c) 2000 Silicon Graphics, Inc.  All Rights Reserved.
+ *  Authors:	William Roske, Dave Fenner
+ *
+ *  06/2019 Ported to new library:
+ *		Christian Amann <camann@suse.com>
+ */
+/*
+ * Basic test for lstat():
+ *
+ * Tests if lstat() writes correct information about a symlink
+ * into the stat structure.
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include "tst_test.h"
+
+#define TESTFILE        "/tmp/tst_file"
+#define TESTSYML        "/tmp/tst_syml"
+
+static uid_t user_id;
+static gid_t group_id;
+
+static void run(void)
+{
+	tst_res(TPASS, "No test function defined here");
+}
+
+static void setup(void)
+{
+	user_id  = getuid();
+	group_id = getgid();
+
+	SAFE_TOUCH(TESTFILE, 0644, NULL);
+	SAFE_SYMLINK(TESTFILE, TESTSYML);
+}
+
+static void cleanup(void)
+{}
+
+static struct tst_test test = {
+	.test_all = run,
+	.setup = setup,
+	.needs_tmpdir = 1,
+};

--- a/ltp_src/testcases/kernel/syscalls/open/open02_run.c
+++ b/ltp_src/testcases/kernel/syscalls/open/open02_run.c
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) International Business Machines Corp., 2001
+ * Ported to LTP: Wayne Boyer
+ *	06/2017 Modified by Guangwen Feng <fenggw-fnst@cn.fujitsu.com>
+ */
+/*
+ * DESCRIPTION
+ *	1. open a new file without O_CREAT, ENOENT should be returned.
+ *	2. open a file with O_RDONLY | O_NOATIME and the caller was not
+ *	   privileged, EPERM should be returned.
+ */
+
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <pwd.h>
+#include "tst_test.h"
+
+#define TEST_FILE	"/tmp/test_file"
+#define TEST_FILE2	"/tmp/test_file2"
+
+static struct tcase {
+	char *filename;
+	int flag;
+	int exp_errno;
+} tcases[] = {
+	{TEST_FILE, O_RDWR, ENOENT},
+	{TEST_FILE2, O_RDONLY | O_NOATIME, EPERM},
+};
+
+void setup(void)
+{
+	// struct passwd *ltpuser;
+
+	// SAFE_TOUCH(TEST_FILE2, 0644, NULL);
+
+	// ltpuser = SAFE_GETPWNAM("nobody");
+
+	// SAFE_SETEUID(ltpuser->pw_uid);
+}
+
+static void verify_open(unsigned int n)
+{
+	struct tcase *tc = &tcases[n];
+
+	TEST(open(tc->filename, tc->flag, 0444));
+
+	if (TST_RET != -1) {
+		tst_res(TFAIL, "open(%s) succeeded unexpectedly",
+			tc->filename);
+		return;
+	}
+
+	if (tc->exp_errno != TST_ERR) {
+		tst_res(TFAIL | TTERRNO,
+			"open() should fail with %s",
+			tst_strerrno(tc->exp_errno));
+		return;
+	}
+
+	tst_res(TPASS | TTERRNO, "open() failed as expected");
+}
+
+void cleanup(void)
+{
+	// SAFE_SETEUID(0);
+}
+
+static struct tst_test test = {
+	.tcnt = ARRAY_SIZE(tcases),
+	.needs_root = 1,
+	.needs_tmpdir = 1,
+	.setup = setup,
+	.cleanup = cleanup,
+	.test = verify_open,
+};

--- a/ltp_src/testcases/kernel/syscalls/open/open02_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/open/open02_setup.c
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) International Business Machines Corp., 2001
+ * Ported to LTP: Wayne Boyer
+ *	06/2017 Modified by Guangwen Feng <fenggw-fnst@cn.fujitsu.com>
+ */
+/*
+ * DESCRIPTION
+ *	1. open a new file without O_CREAT, ENOENT should be returned.
+ *	2. open a file with O_RDONLY | O_NOATIME and the caller was not
+ *	   privileged, EPERM should be returned.
+ */
+
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <pwd.h>
+#include "tst_test.h"
+
+#define TEST_FILE	"/tmp/test_file"
+#define TEST_FILE2	"/tmp/test_file2"
+
+static struct tcase {
+	char *filename;
+	int flag;
+	int exp_errno;
+} tcases[] = {
+	{TEST_FILE, O_RDWR, ENOENT},
+	{TEST_FILE2, O_RDONLY | O_NOATIME, EPERM},
+};
+
+void setup(void)
+{
+	struct passwd *ltpuser;
+
+	SAFE_TOUCH(TEST_FILE2, 0644, NULL);
+
+	ltpuser = SAFE_GETPWNAM("nobody");
+
+	SAFE_SETEUID(ltpuser->pw_uid);
+}
+
+static void verify_open(unsigned int n)
+{
+    tst_res(TPASS, "No test functions here");
+}
+
+void cleanup(void)
+{
+	// SAFE_SETEUID(0);
+}
+
+static struct tst_test test = {
+	.tcnt = ARRAY_SIZE(tcases),
+	.needs_tmpdir = 1,
+	.setup = setup,
+	.cleanup = cleanup,
+	.test = verify_open,
+};

--- a/ltp_src/testcases/kernel/syscalls/open/open07_run.c
+++ b/ltp_src/testcases/kernel/syscalls/open/open07_run.c
@@ -1,0 +1,250 @@
+/*
+ *
+ *   Copyright (c) International Business Machines  Corp., 2001
+ *
+ *   This program is free software;  you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *   the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program;  if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * NAME
+ *	open07.c
+ *
+ * DESCRIPTION
+ *	Test the open(2) system call to ensure that it sets ELOOP correctly.
+ *
+ * CALLS
+ *	open()
+ *
+ * ALGORITHM
+ *	1. Create a symbolic link to a file, and call open(O_NOFOLLOW). Check
+ *	   that it returns ELOOP.
+ *
+ *	2. Create a symbolic link to a directory, and call open(O_NOFOLLOW).
+ *	   Check that it returns ELOOP.
+ *
+ *	3. Create a symbolic link to a symbolic link, and call open(O_NOFOLLOW).
+ *	   Check that it returns ELOOP.
+ *
+ *	4. Create a symbolic link to a symbolically linked directory, and call
+ *	   open(O_NOFOLLOW). Check that it returns ELOOP.
+ *
+ *	5. Create a symbolic link to a directory, and call
+ *         open("link/", O_NOFOLLOW). Check that it succeeds.
+ *
+ * USAGE:  <for command-line>
+ *  open07 [-c n] [-e] [-i n] [-I x] [-P x] [-t]
+ *     where,  -c n : Run n copies concurrently.
+ *             -e   : Turn on errno logging.
+ *             -i n : Execute test n times.
+ *             -I x : Execute test for x seconds.
+ *             -P x : Pause for x seconds between iterations.
+ *             -t   : Turn on syscall timing.
+ *
+ * HISTORY
+ *	07/2001 Ported by Wayne Boyer
+ *
+ * RESTRICTIONS
+ *	None
+ */
+#define _GNU_SOURCE		/* for O_NOFOLLOW */
+#include <stdio.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include "test.h"
+#include "safe_macros.h"
+
+static void setup(void);
+static void cleanup(void);
+static void setupfunc_test1();
+static void setupfunc_test2();
+static void setupfunc_test3();
+static void setupfunc_test4();
+static void setupfunc_test5();
+
+char *TCID = "open07";
+int TST_TOTAL = 5;
+
+static int fd1, fd2;
+
+static struct test_case_t {
+	char *desc;
+	char filename[100];
+	int flags;
+	int mode;
+	void (*setupfunc) ();
+	int exp_errno;
+} TC[] = {
+	{"Test for ELOOP on f2: f1 -> f2", {},
+	 O_NOFOLLOW, 00700, setupfunc_test1, ELOOP},
+	{"Test for ELOOP on d2: d1 -> d2", {},
+	 O_NOFOLLOW, 00700, setupfunc_test2, ELOOP},
+	{"Test for ELOOP on f3: f1 -> f2 -> f3", {},
+	 O_NOFOLLOW, 00700, setupfunc_test3, ELOOP},
+	{"Test for ELOOP on d3: d1 -> d2 -> d3", {},
+	 O_NOFOLLOW, 00700, setupfunc_test4, ELOOP},
+	{"Test for success on d2: d1 -> d2", {},
+	 O_NOFOLLOW, 00700, setupfunc_test5, 0},
+	{NULL, {}, 0, 0, NULL, 0}
+};
+
+int main(int ac, char **av)
+{
+	int lc;
+	int i;
+
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	setup();
+
+	/* run the setup routines for the individual tests */
+	for (i = 0; i < TST_TOTAL; i++) {
+		if (TC[i].setupfunc != NULL)
+			TC[i].setupfunc();
+	}
+
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+		tst_count = 0;
+
+		for (i = 0; TC[i].desc != NULL; ++i) {
+			TEST(open(TC[i].filename, TC[i].flags, TC[i].mode));
+
+			if (TC[i].exp_errno != 0) {
+				if (TEST_RETURN != -1) {
+					tst_resm(TFAIL, "open succeeded "
+						 "unexpectedly");
+				}
+
+				if (TEST_ERRNO != TC[i].exp_errno) {
+					tst_resm(TFAIL, "open returned "
+						 "unexpected errno, expected: "
+						 "%d, got: %d",
+						 TC[i].exp_errno, TEST_ERRNO);
+				} else {
+					tst_resm(TPASS, "open returned "
+						 "expected ELOOP error");
+				}
+			} else {
+				if (TEST_RETURN == -1) {
+					tst_resm(TFAIL, "open failed "
+						 "unexpectedly with errno %d",
+						 TEST_ERRNO);
+				} else {
+					tst_resm(TPASS, "open succeeded as "
+						 "expected");
+				}
+			}
+
+			if (TEST_RETURN != -1)
+				close(TEST_RETURN);
+		}
+	}
+
+	cleanup();
+	tst_exit();
+}
+
+static void setupfunc_test1(void)
+{
+	char file1[100] = "/tmp/file1", file2[100] = "/tmp/file2";
+
+	// sprintf(file1, "open03.1.%d", getpid());
+	// sprintf(file2, "open03.2.%d", getpid());
+	// fd1 = SAFE_CREAT(cleanup, file1, 00700);
+
+	// SAFE_SYMLINK(cleanup, file1, file2);
+
+	strcpy(TC[0].filename, file2);
+}
+
+static void setupfunc_test2(void)
+{
+	char file1[100] = "/tmp/file1", file2[100] = "/tmp/file2";
+
+	// sprintf(file1, "open03.3.%d", getpid());
+	// sprintf(file2, "open03.4.%d", getpid());
+	// SAFE_MKDIR(cleanup, file1, 00700);
+
+	// SAFE_SYMLINK(cleanup, file1, file2);
+
+	strcpy(TC[1].filename, file2);
+}
+
+static void setupfunc_test3(void)
+{
+	char file1[100] = "/tmp/file1", file2[100] = "/tmp/file2", file3[100] = "/tmp/file3";
+
+	// sprintf(file1, "open03.5.%d", getpid());
+	// sprintf(file2, "open03.6.%d", getpid());
+	// sprintf(file3, "open03.7.%d", getpid());
+	// fd2 = SAFE_CREAT(cleanup, file1, 00700);
+
+	// SAFE_SYMLINK(cleanup, file1, file2);
+
+	// SAFE_SYMLINK(cleanup, file2, file3);
+
+	strcpy(TC[2].filename, file3);
+}
+
+static void setupfunc_test4(void)
+{
+	char file1[100] = "/tmp/file1", file2[100] = "/tmp/file2", file3[100] = "/tmp/file3";
+
+	// sprintf(file1, "open03.8.%d", getpid());
+	// sprintf(file2, "open03.9.%d", getpid());
+	// sprintf(file3, "open03.10.%d", getpid());
+	// SAFE_MKDIR(cleanup, file1, 00700);
+
+	// SAFE_SYMLINK(cleanup, file1, file2);
+
+	// SAFE_SYMLINK(cleanup, file2, file3);
+
+	strcpy(TC[3].filename, file3);
+}
+
+static void setupfunc_test5(void)
+{
+	// char file1[100], file2[100];
+	char file1[100] = "/tmp/file1", file2[100] = "/tmp/file2";
+
+	// sprintf(file1, "open11.3.%d", getpid());
+	// sprintf(file2, "open12.4.%d", getpid());
+	// SAFE_MKDIR(cleanup, file1, 00700);
+
+	// SAFE_SYMLINK(cleanup, file1, file2);
+
+	strcpy(TC[4].filename, file2);
+	strcat(TC[4].filename, "/tmp");
+}
+
+static void setup(void)
+{
+	// umask(0);
+
+	// tst_sig(NOFORK, DEF_HANDLER, cleanup);
+
+	// TEST_PAUSE;
+
+	// tst_tmpdir();
+}
+
+static void cleanup(void)
+{
+	close(fd1);
+	close(fd2);
+
+	tst_rmdir();
+}

--- a/ltp_src/testcases/kernel/syscalls/open/open07_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/open/open07_setup.c
@@ -1,0 +1,250 @@
+/*
+ *
+ *   Copyright (c) International Business Machines  Corp., 2001
+ *
+ *   This program is free software;  you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *   the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program;  if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * NAME
+ *	open07.c
+ *
+ * DESCRIPTION
+ *	Test the open(2) system call to ensure that it sets ELOOP correctly.
+ *
+ * CALLS
+ *	open()
+ *
+ * ALGORITHM
+ *	1. Create a symbolic link to a file, and call open(O_NOFOLLOW). Check
+ *	   that it returns ELOOP.
+ *
+ *	2. Create a symbolic link to a directory, and call open(O_NOFOLLOW).
+ *	   Check that it returns ELOOP.
+ *
+ *	3. Create a symbolic link to a symbolic link, and call open(O_NOFOLLOW).
+ *	   Check that it returns ELOOP.
+ *
+ *	4. Create a symbolic link to a symbolically linked directory, and call
+ *	   open(O_NOFOLLOW). Check that it returns ELOOP.
+ *
+ *	5. Create a symbolic link to a directory, and call
+ *         open("link/", O_NOFOLLOW). Check that it succeeds.
+ *
+ * USAGE:  <for command-line>
+ *  open07 [-c n] [-e] [-i n] [-I x] [-P x] [-t]
+ *     where,  -c n : Run n copies concurrently.
+ *             -e   : Turn on errno logging.
+ *             -i n : Execute test n times.
+ *             -I x : Execute test for x seconds.
+ *             -P x : Pause for x seconds between iterations.
+ *             -t   : Turn on syscall timing.
+ *
+ * HISTORY
+ *	07/2001 Ported by Wayne Boyer
+ *
+ * RESTRICTIONS
+ *	None
+ */
+#define _GNU_SOURCE		/* for O_NOFOLLOW */
+#include <stdio.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include "test.h"
+#include "safe_macros.h"
+
+static void setup(void);
+static void cleanup(void);
+static void setupfunc_test1();
+static void setupfunc_test2();
+static void setupfunc_test3();
+static void setupfunc_test4();
+static void setupfunc_test5();
+
+char *TCID = "open07";
+int TST_TOTAL = 5;
+
+static int fd1, fd2;
+
+static struct test_case_t {
+	char *desc;
+	char filename[100];
+	int flags;
+	int mode;
+	void (*setupfunc) ();
+	int exp_errno;
+} TC[] = {
+	{"Test for ELOOP on f2: f1 -> f2", {},
+	 O_NOFOLLOW, 00700, setupfunc_test1, ELOOP},
+	{"Test for ELOOP on d2: d1 -> d2", {},
+	 O_NOFOLLOW, 00700, setupfunc_test2, ELOOP},
+	{"Test for ELOOP on f3: f1 -> f2 -> f3", {},
+	 O_NOFOLLOW, 00700, setupfunc_test3, ELOOP},
+	{"Test for ELOOP on d3: d1 -> d2 -> d3", {},
+	 O_NOFOLLOW, 00700, setupfunc_test4, ELOOP},
+	{"Test for success on d2: d1 -> d2", {},
+	 O_NOFOLLOW, 00700, setupfunc_test5, 0},
+	{NULL, {}, 0, 0, NULL, 0}
+};
+
+int main(int ac, char **av)
+{
+	int lc;
+	int i;
+
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	setup();
+
+	/* run the setup routines for the individual tests */
+	for (i = 0; i < TST_TOTAL; i++) {
+		if (TC[i].setupfunc != NULL)
+			TC[i].setupfunc();
+	}
+
+	// for (lc = 0; TEST_LOOPING(lc); lc++) {
+	// 	tst_count = 0;
+
+	// 	for (i = 0; TC[i].desc != NULL; ++i) {
+	// 		TEST(open(TC[i].filename, TC[i].flags, TC[i].mode));
+
+	// 		if (TC[i].exp_errno != 0) {
+	// 			if (TEST_RETURN != -1) {
+	// 				tst_resm(TFAIL, "open succeeded "
+	// 					 "unexpectedly");
+	// 			}
+
+	// 			if (TEST_ERRNO != TC[i].exp_errno) {
+	// 				tst_resm(TFAIL, "open returned "
+	// 					 "unexpected errno, expected: "
+	// 					 "%d, got: %d",
+	// 					 TC[i].exp_errno, TEST_ERRNO);
+	// 			} else {
+	// 				tst_resm(TPASS, "open returned "
+	// 					 "expected ELOOP error");
+	// 			}
+	// 		} else {
+	// 			if (TEST_RETURN == -1) {
+	// 				tst_resm(TFAIL, "open failed "
+	// 					 "unexpectedly with errno %d",
+	// 					 TEST_ERRNO);
+	// 			} else {
+	// 				tst_resm(TPASS, "open succeeded as "
+	// 					 "expected");
+	// 			}
+	// 		}
+
+	// 		if (TEST_RETURN != -1)
+	// 			close(TEST_RETURN);
+	// 	}
+	// }
+
+	// cleanup();
+	// tst_exit();
+}
+
+static void setupfunc_test1(void)
+{
+	char file1[100] = "/tmp/file1", file2[100] = "/tmp/file2";
+
+	// sprintf(file1, "open03.1.%d", getpid());
+	// sprintf(file2, "open03.2.%d", getpid());
+	fd1 = SAFE_CREAT(cleanup, file1, 00700);
+
+	SAFE_SYMLINK(cleanup, file1, file2);
+
+	strcpy(TC[0].filename, file2);
+}
+
+static void setupfunc_test2(void)
+{
+	char file1[100] = "/tmp/file1", file2[100] = "/tmp/file2";
+
+	// sprintf(file1, "open03.3.%d", getpid());
+	// sprintf(file2, "open03.4.%d", getpid());
+	SAFE_MKDIR(cleanup, file1, 00700);
+
+	SAFE_SYMLINK(cleanup, file1, file2);
+
+	strcpy(TC[1].filename, file2);
+}
+
+static void setupfunc_test3(void)
+{
+	char file1[100] = "/tmp/file1", file2[100] = "/tmp/file2", file3[100] = "/tmp/file3";
+
+	sprintf(file1, "open03.5.%d", getpid());
+	sprintf(file2, "open03.6.%d", getpid());
+	sprintf(file3, "open03.7.%d", getpid());
+	fd2 = SAFE_CREAT(cleanup, file1, 00700);
+
+	SAFE_SYMLINK(cleanup, file1, file2);
+
+	SAFE_SYMLINK(cleanup, file2, file3);
+
+	strcpy(TC[2].filename, file3);
+}
+
+static void setupfunc_test4(void)
+{
+	char file1[100] = "/tmp/file1", file2[100] = "/tmp/file2", file3[100] = "/tmp/file3";
+
+	sprintf(file1, "open03.8.%d", getpid());
+	sprintf(file2, "open03.9.%d", getpid());
+	sprintf(file3, "open03.10.%d", getpid());
+	SAFE_MKDIR(cleanup, file1, 00700);
+
+	SAFE_SYMLINK(cleanup, file1, file2);
+
+	SAFE_SYMLINK(cleanup, file2, file3);
+
+	strcpy(TC[3].filename, file3);
+}
+
+static void setupfunc_test5(void)
+{
+	// char file1[100], file2[100];
+	char file1[100] = "/tmp/file1", file2[100] = "/tmp/file2";
+
+	sprintf(file1, "open11.3.%d", getpid());
+	sprintf(file2, "open12.4.%d", getpid());
+	SAFE_MKDIR(cleanup, file1, 00700);
+
+	SAFE_SYMLINK(cleanup, file1, file2);
+
+	strcpy(TC[4].filename, file2);
+	strcat(TC[4].filename, "/tmp");
+}
+
+static void setup(void)
+{
+	umask(0);
+
+	tst_sig(NOFORK, DEF_HANDLER, cleanup);
+
+	TEST_PAUSE;
+
+	tst_tmpdir();
+}
+
+static void cleanup(void)
+{
+	close(fd1);
+	close(fd2);
+
+	tst_rmdir();
+}

--- a/ltp_src/testcases/kernel/syscalls/open/open11_run.c
+++ b/ltp_src/testcases/kernel/syscalls/open/open11_run.c
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Basic tests for open(2) and make sure open(2) works and handles error
+ * conditions correctly.
+ *
+ * There are 28 test cases:
+ * 1. Open regular file O_RDONLY
+ * 2. Open regular file O_WRONLY
+ * 3. Open regular file O_RDWR
+ * 4. Open regular file O_RDWR | O_SYNC
+ * 5. Open regular file O_RDWR | O_TRUNC
+ * 6. Open dir O_RDONLY
+ * 7. Open dir O_RDWR, expect EISDIR
+ * 8. Open regular file O_DIRECTORY, expect ENOTDIR
+ * 9. Open hard link file O_RDONLY
+ * 10. Open hard link file O_WRONLY
+ * 11. Open hard link file O_RDWR
+ * 12. Open sym link file O_RDONLY
+ * 13. Open sym link file O_WRONLY
+ * 14. Open sym link file O_RDWR
+ * 15. Open sym link dir O_RDONLY
+ * 16. Open sym link dir O_WRONLY, expect EISDIR
+ * 17. Open sym link dir O_RDWR, expect EISDIR
+ * 18. Open device special file O_RDONLY
+ * 19. Open device special file O_WRONLY
+ * 20. Open device special file O_RDWR
+ * 21. Open non-existing regular file in existing dir
+ * 22. Open link file O_RDONLY | O_CREAT
+ * 23. Open symlink file O_RDONLY | O_CREAT
+ * 24. Open regular file O_RDONLY | O_CREAT
+ * 25. Open symlink dir O_RDONLY | O_CREAT, expect EISDIR
+ * 26. Open dir O_RDONLY | O_CREAT, expect EISDIR
+ * 27. Open regular file O_RDONLY | O_TRUNC, behaviour is undefined but should
+ *     not oops or hang
+ * 28. Open regular file(non-empty) O_RDONLY | O_TRUNC, behaviour is undefined
+ *     but should not oops or hang
+ */
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <sys/sysmacros.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "tst_test.h"
+
+#define MNTPOINT "/tmp/mntpoint"
+#define T_REG "/tmp/t_reg"			/* regular file with content */
+#define T_REG_EMPTY "/tmp/t_reg_empty"	/* empty regular file */
+#define T_LINK_REG "/tmp/t_link_reg"		/* hard link to T_REG */
+#define T_NEW_REG "t_new_reg"		/* new regular file to be created */
+#define T_SYMLINK_REG "/tmp/t_symlink_reg"	/* symlink to T_REG */
+#define T_DIR "/tmp/t_dir"			/* test dir */
+#define T_SYMLINK_DIR "/tmp/t_symlink_dir"	/* symlink to T_DIR */
+#define T_DEV MNTPOINT"/t_dev"		/* test device special file */
+
+#define T_MSG "this is a test string"
+
+static struct test_case {
+	char *desc;
+	char *path;
+	int flags;
+	mode_t mode;
+	int err;
+} tc[] = {
+	/* Test open(2) regular file */
+	{	/* open regular file O_RDONLY */
+		.desc = "Open regular file O_RDONLY",
+		.path = T_REG_EMPTY,
+		.flags = O_RDONLY,
+		.mode = 0644,
+		.err = 0,
+	},
+	{	/* open regular file O_WRONLY */
+		.desc = "Open regular file O_WRONLY",
+		.path = T_REG_EMPTY,
+		.flags = O_WRONLY,
+		.mode = 0644,
+		.err = 0,
+	},
+	{	/* open regular file O_RDWR */
+		.desc = "Open regular file O_RDWR",
+		.path = T_REG_EMPTY,
+		.flags = O_RDWR,
+		.mode = 0644,
+		.err = 0,
+	},
+	{	/* open regular file O_RDWR | O_SYNC*/
+		.desc = "Open regular file O_RDWR | O_SYNC",
+		.path = T_REG_EMPTY,
+		.flags = O_RDWR | O_SYNC,
+		.mode = 0644,
+		.err = 0,
+	},
+	{	/* open regular file O_RDWR | O_TRUNC */
+		.desc = "Open regular file O_RDWR | O_TRUNC",
+		.path = T_REG_EMPTY,
+		.flags = O_RDWR | O_TRUNC,
+		.mode = 0644,
+		.err = 0,
+	},
+	/* Test open(2) directory */
+	{	/* open dir O_RDONLY */
+		.desc = "Open dir O_RDONLY",
+		.path = T_DIR,
+		.flags = O_RDONLY,
+		.mode = 0755,
+		.err = 0,
+	},
+	{	/* open dir O_RDWR */
+		.desc = "Open dir O_RDWR, expect EISDIR",
+		.path = T_DIR,
+		.flags = O_RDWR,
+		.mode = 0755,
+		.err = EISDIR,
+	},
+	{	/* open regular file O_DIRECTORY */
+		.desc = "Open regular file O_DIRECTORY, expect ENOTDIR",
+		.path = T_REG_EMPTY,
+		.flags = O_RDONLY | O_DIRECTORY,
+		.mode = 0644,
+		.err = ENOTDIR,
+	},
+	/* Test open(2) hard link */
+	{	/* open hard link file O_RDONLY */
+		.desc = "Open hard link file O_RDONLY",
+		.path = T_LINK_REG,
+		.flags = O_RDONLY,
+		.mode = 0644,
+		.err = 0,
+	},
+	{	/* open hard link file O_WRONLY */
+		.desc = "Open hard link file O_WRONLY",
+		.path = T_LINK_REG,
+		.flags = O_WRONLY,
+		.mode = 0644,
+		.err = 0,
+	},
+	{	/* open hard link file O_RDWR */
+		.desc = "Open hard link file O_RDWR",
+		.path = T_LINK_REG,
+		.flags = O_RDWR,
+		.mode = 0644,
+		.err = 0,
+	},
+	/* Test open(2) sym link */
+	{	/* open sym link file O_RDONLY */
+		.desc = "Open sym link file O_RDONLY",
+		.path = T_SYMLINK_REG,
+		.flags = O_RDONLY,
+		.mode = 0644,
+		.err = 0,
+	},
+	{	/* open sym link file O_WRONLY */
+		.desc = "Open sym link file O_WRONLY",
+		.path = T_SYMLINK_REG,
+		.flags = O_WRONLY,
+		.mode = 0644,
+		.err = 0,
+	},
+	{	/* open sym link file O_RDWR */
+		.desc = "Open sym link file O_RDWR",
+		.path = T_SYMLINK_REG,
+		.flags = O_RDWR,
+		.mode = 0644,
+		.err = 0,
+	},
+	{	/* open sym link dir O_RDONLY */
+		.desc = "Open sym link dir O_RDONLY",
+		.path = T_SYMLINK_DIR,
+		.flags = O_RDONLY,
+		.mode = 0644,
+		.err = 0,
+	},
+	{	/* open sym link dir O_WRONLY */
+		.desc = "Open sym link dir O_WRONLY, expect EISDIR",
+		.path = T_SYMLINK_DIR,
+		.flags = O_WRONLY,
+		.mode = 0644,
+		.err = EISDIR,
+	},
+	{	/* open sym link dir O_RDWR */
+		.desc = "Open sym link dir O_RDWR, expect EISDIR",
+		.path = T_SYMLINK_DIR,
+		.flags = O_RDWR,
+		.mode = 0644,
+		.err = EISDIR,
+	},
+	/* * Test open(2) device special */
+	{	/* open device special file O_RDONLY */
+		.desc = "Open device special file O_RDONLY",
+		.path = T_DEV,
+		.flags = O_RDONLY,
+		.mode = 0644,
+		.err = 0,
+	},
+	{	/* open device special file O_WRONLY */
+		.desc = "Open device special file O_WRONLY",
+		.path = T_DEV,
+		.flags = O_WRONLY,
+		.mode = 0644,
+		.err = 0,
+	},
+	{	/* open device special file O_RDWR */
+		.desc = "Open device special file O_RDWR",
+		.path = T_DEV,
+		.flags = O_RDWR,
+		.mode = 0644,
+		.err = 0,
+	},
+	/* * Test open(2) non-existing file */
+	{	/* open non-existing regular file in existing dir */
+		.desc = "Open non-existing regular file in existing dir",
+		.path = T_DIR"/"T_NEW_REG,
+		.flags = O_RDWR | O_CREAT,
+		.mode = 0644,
+		.err = 0,
+	},
+	/* test open(2) with O_CREAT */
+	{	/* open hard link file O_RDONLY | O_CREAT */
+		.desc = "Open link file O_RDONLY | O_CREAT",
+		.path = T_LINK_REG,
+		.flags = O_RDONLY | O_CREAT,
+		.mode = 0644,
+		.err = 0,
+	},
+	{	/* open sym link file O_RDONLY | O_CREAT */
+		.desc = "Open symlink file O_RDONLY | O_CREAT",
+		.path = T_SYMLINK_REG,
+		.flags = O_RDONLY | O_CREAT,
+		.mode = 0644,
+		.err = 0,
+	},
+	{	/* open regular file O_RDONLY | O_CREAT */
+		.desc = "Open regular file O_RDONLY | O_CREAT",
+		.path = T_REG_EMPTY,
+		.flags = O_RDONLY | O_CREAT,
+		.mode = 0644,
+		.err = 0,
+	},
+	{	/* open symlink dir O_RDONLY | O_CREAT */
+		.desc = "Open symlink dir O_RDONLY | O_CREAT, expect EISDIR",
+		.path = T_SYMLINK_DIR,
+		.flags = O_RDONLY | O_CREAT,
+		.mode = 0644,
+		.err = EISDIR,
+	},
+	{	/* open dir O_RDONLY | O_CREAT */
+		.desc = "Open dir O_RDONLY | O_CREAT, expect EISDIR",
+		.path = T_DIR,
+		.flags = O_RDONLY | O_CREAT,
+		.mode = 0644,
+		.err = EISDIR,
+	},
+	/* Other random open(2) tests */
+	{	/* open regular file O_RDONLY | O_TRUNC */
+		.desc = "Open regular file O_RDONLY | O_TRUNC, "
+			"behaviour is undefined but should not oops or hang",
+		.path = T_REG_EMPTY,
+		.flags = O_RDONLY | O_TRUNC,
+		.mode = 0644,
+		.err = -1,
+	},
+	{	/* open regular(non-empty) file O_RDONLY | O_TRUNC */
+		.desc = "Open regular file(non-empty) O_RDONLY | O_TRUNC, "
+			"behaviour is undefined but should not oops or hang",
+		.path = T_REG,
+		.flags = O_RDONLY | O_TRUNC,
+		.mode = 0644,
+		.err = -1,
+	},
+};
+
+static void verify_open(unsigned int n)
+{
+	int fd;
+
+	TEST(open(tc[n].path, tc[n].flags, tc[n].mode));
+	fd = TST_RET;
+
+	if (fd > 0)
+		SAFE_CLOSE(fd);
+
+	if (tc[n].err == -1 || TST_ERR == tc[n].err) {
+		tst_res(TPASS, "%s", tc[n].desc);
+		return;
+	}
+
+	tst_res(TFAIL | TTERRNO, "%s - expected %s",
+			tc[n].desc, tst_strerrno(tc[n].err));
+}
+
+static void setup(void)
+{
+	// SAFE_MKNOD(T_DEV, S_IFCHR, makedev(1, 5));
+}
+
+static struct tst_test test = {
+	.tcnt = ARRAY_SIZE(tc),
+	.setup = setup,
+	.test = verify_open,
+};

--- a/ltp_src/testcases/kernel/syscalls/open/open11_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/open/open11_setup.c
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Basic tests for open(2) and make sure open(2) works and handles error
+ * conditions correctly.
+ *
+ * There are 28 test cases:
+ * 1. Open regular file O_RDONLY
+ * 2. Open regular file O_WRONLY
+ * 3. Open regular file O_RDWR
+ * 4. Open regular file O_RDWR | O_SYNC
+ * 5. Open regular file O_RDWR | O_TRUNC
+ * 6. Open dir O_RDONLY
+ * 7. Open dir O_RDWR, expect EISDIR
+ * 8. Open regular file O_DIRECTORY, expect ENOTDIR
+ * 9. Open hard link file O_RDONLY
+ * 10. Open hard link file O_WRONLY
+ * 11. Open hard link file O_RDWR
+ * 12. Open sym link file O_RDONLY
+ * 13. Open sym link file O_WRONLY
+ * 14. Open sym link file O_RDWR
+ * 15. Open sym link dir O_RDONLY
+ * 16. Open sym link dir O_WRONLY, expect EISDIR
+ * 17. Open sym link dir O_RDWR, expect EISDIR
+ * 18. Open device special file O_RDONLY
+ * 19. Open device special file O_WRONLY
+ * 20. Open device special file O_RDWR
+ * 21. Open non-existing regular file in existing dir
+ * 22. Open link file O_RDONLY | O_CREAT
+ * 23. Open symlink file O_RDONLY | O_CREAT
+ * 24. Open regular file O_RDONLY | O_CREAT
+ * 25. Open symlink dir O_RDONLY | O_CREAT, expect EISDIR
+ * 26. Open dir O_RDONLY | O_CREAT, expect EISDIR
+ * 27. Open regular file O_RDONLY | O_TRUNC, behaviour is undefined but should
+ *     not oops or hang
+ * 28. Open regular file(non-empty) O_RDONLY | O_TRUNC, behaviour is undefined
+ *     but should not oops or hang
+ */
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <sys/sysmacros.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "tst_test.h"
+
+#define MNTPOINT "/tmp/mntpoint"
+#define T_REG "/tmp/t_reg"			/* regular file with content */
+#define T_REG_EMPTY "/tmp/t_reg_empty"	/* empty regular file */
+#define T_LINK_REG "/tmp/t_link_reg"		/* hard link to T_REG */
+#define T_NEW_REG "t_new_reg"		/* new regular file to be created */
+#define T_SYMLINK_REG "/tmp/t_symlink_reg"	/* symlink to T_REG */
+#define T_DIR "/tmp/t_dir"			/* test dir */
+#define T_SYMLINK_DIR "/tmp/t_symlink_dir"	/* symlink to T_DIR */
+#define T_DEV MNTPOINT"/t_dev"		/* test device special file */
+
+#define T_MSG "this is a test string"
+
+static struct test_case {
+	char *desc;
+	char *path;
+	int flags;
+	mode_t mode;
+	int err;
+} tc[] = {
+	/* Test open(2) regular file */
+	{	/* open regular file O_RDONLY */
+		.desc = "Open regular file O_RDONLY",
+		.path = T_REG_EMPTY,
+		.flags = O_RDONLY,
+		.mode = 0644,
+		.err = 0,
+	},
+};
+
+static void verify_open(unsigned int n)
+{
+	tst_res(TPASS, "No Test function defined");
+}
+
+static void setup(void)
+{
+	int fd;
+	int ret;
+
+	fd = SAFE_OPEN(T_REG, O_WRONLY | O_CREAT, 0644);
+	ret = write(fd, T_MSG, sizeof(T_MSG));
+	if (ret == -1) {
+		SAFE_CLOSE(fd);
+		tst_brk(TBROK | TERRNO, "Write %s failed", T_REG);
+	}
+	SAFE_CLOSE(fd);
+
+	SAFE_TOUCH(T_REG_EMPTY, 0644, NULL);
+	SAFE_LINK(T_REG, T_LINK_REG);
+	SAFE_SYMLINK(T_REG, T_SYMLINK_REG);
+	SAFE_MKDIR(T_DIR, 0755);
+	SAFE_SYMLINK(T_DIR, T_SYMLINK_DIR);
+	SAFE_MKNOD(T_DEV, S_IFCHR, makedev(1, 5));
+}
+
+static struct tst_test test = {
+	.tcnt = ARRAY_SIZE(tc),
+	.setup = setup,
+	.test = verify_open,
+	.needs_devfs = 1,
+	.mntpoint = MNTPOINT,
+};

--- a/ltp_src/testcases/kernel/syscalls/open/open13_run.c
+++ b/ltp_src/testcases/kernel/syscalls/open/open13_run.c
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2015 Fujitsu Ltd.
+ * Author: Guangwen Feng <fenggw-fnst@cn.fujitsu.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.
+ */
+
+/*
+ * DESCRIPTION
+ *  Basic test for O_PATH flag of open(2).
+ *  "Obtain a file descriptor that can be used to perform operations
+ *   that act purely at the file descriptor level, the file itself is
+ *   not opened, the operations read(2), write(2), fchmod(2), fchown(2)
+ *   and fgetxattr(2) fail with the error EBADF."
+ *
+ *  The operations include but are not limited to the syscalls above.
+ */
+
+#define _GNU_SOURCE
+
+#include "config.h"
+
+#include <errno.h>
+#ifdef HAVE_SYS_XATTR_H
+#include <sys/types.h>
+#include <sys/xattr.h>
+#endif
+
+#include "test.h"
+#include "safe_macros.h"
+#include "lapi/fcntl.h"
+
+#define TESTFILE	"/tmp/testfile"
+#define FILE_MODE	(S_IRWXU | S_IRWXG | S_IRWXO | S_ISUID | S_ISGID)
+
+static void setup(void);
+static void verify_read(void);
+static void verify_write(void);
+static void verify_fchmod(void);
+static void verify_fchown(void);
+#ifdef HAVE_SYS_XATTR_H
+static void verify_fgetxattr(void);
+#endif
+static void check_result(const char *call_name);
+static void cleanup(void);
+
+static int fd;
+
+static void (*test_func[])(void) = {
+	verify_read,
+	verify_write,
+	verify_fchmod,
+	verify_fchown,
+#ifdef HAVE_SYS_XATTR_H
+	verify_fgetxattr
+#endif
+};
+
+char *TCID = "open13";
+int TST_TOTAL = ARRAY_SIZE(test_func);
+
+int main(int ac, char **av)
+{
+	int lc;
+	int tc;
+
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	setup();
+
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+		tst_count = 0;
+
+		fd = SAFE_OPEN(cleanup, TESTFILE, O_RDWR | O_PATH);
+
+		for (tc = 0; tc < TST_TOTAL; tc++)
+			(*test_func[tc])();
+
+		SAFE_CLOSE(cleanup, fd);
+		fd = 0;
+	}
+
+	cleanup();
+	tst_exit();
+}
+
+static void setup(void)
+{}
+
+static void verify_read(void)
+{
+	char buf[255];
+
+	TEST(read(fd, buf, sizeof(buf)));
+	check_result("read(2)");
+}
+
+static void verify_write(void)
+{
+	TEST(write(fd, "w", 1));
+	check_result("write(2)");
+}
+
+static void verify_fchmod(void)
+{
+	TEST(fchmod(fd, 0666));
+	check_result("fchmod(2)");
+}
+
+static void verify_fchown(void)
+{
+	TEST(fchown(fd, 1000, 1000));
+	check_result("fchown(2)");
+}
+
+#ifdef HAVE_SYS_XATTR_H
+static void verify_fgetxattr(void)
+{
+	TEST(fgetxattr(fd, "tkey", NULL, 1));
+	check_result("fgetxattr(2)");
+}
+#endif
+
+static void check_result(const char *call_name)
+{
+	if (TEST_RETURN == 0) {
+		tst_resm(TFAIL, "%s succeeded unexpectedly", call_name);
+		return;
+	}
+
+	if (TEST_ERRNO != EBADF) {
+		tst_resm(TFAIL | TTERRNO, "%s failed unexpectedly, "
+			"expected EBADF", call_name);
+		return;
+	}
+
+	tst_resm(TPASS, "%s failed with EBADF", call_name);
+}
+
+static void cleanup(void)
+{
+	if (fd > 0 && close(fd))
+		tst_resm(TWARN | TERRNO, "failed to close file");
+
+}

--- a/ltp_src/testcases/kernel/syscalls/open/open13_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/open/open13_setup.c
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2015 Fujitsu Ltd.
+ * Author: Guangwen Feng <fenggw-fnst@cn.fujitsu.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.
+ */
+
+/*
+ * DESCRIPTION
+ *  Basic test for O_PATH flag of open(2).
+ *  "Obtain a file descriptor that can be used to perform operations
+ *   that act purely at the file descriptor level, the file itself is
+ *   not opened, the operations read(2), write(2), fchmod(2), fchown(2)
+ *   and fgetxattr(2) fail with the error EBADF."
+ *
+ *  The operations include but are not limited to the syscalls above.
+ */
+
+#define _GNU_SOURCE
+
+#include "config.h"
+
+#include <errno.h>
+#ifdef HAVE_SYS_XATTR_H
+#include <sys/types.h>
+#include <sys/xattr.h>
+#endif
+
+#include "test.h"
+#include "safe_macros.h"
+#include "lapi/fcntl.h"
+
+#define TESTFILE	"/tmp/testfile"
+#define FILE_MODE	(S_IRWXU | S_IRWXG | S_IRWXO | S_ISUID | S_ISGID)
+
+static void setup(void);
+static void verify_read(void);
+static void verify_write(void);
+static void verify_fchmod(void);
+static void verify_fchown(void);
+#ifdef HAVE_SYS_XATTR_H
+static void verify_fgetxattr(void);
+#endif
+static void check_result(const char *call_name);
+static void cleanup(void);
+
+static int fd;
+
+static void (*test_func[])(void) = {
+	verify_read,
+	verify_write,
+	verify_fchmod,
+	verify_fchown,
+#ifdef HAVE_SYS_XATTR_H
+	verify_fgetxattr
+#endif
+};
+
+char *TCID = "open13";
+int TST_TOTAL = ARRAY_SIZE(test_func);
+
+int main(int ac, char **av)
+{
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	setup();
+
+	cleanup();
+}
+
+static void setup(void)
+{
+	if ((tst_kvercmp(2, 6, 39)) < 0) {
+		tst_brkm(TCONF, NULL, "This test can only run on kernels "
+			"that are 2.6.39 or higher");
+	}
+
+	tst_sig(NOFORK, DEF_HANDLER, cleanup);
+
+	tst_tmpdir();
+
+	SAFE_TOUCH(cleanup, TESTFILE, FILE_MODE, NULL);
+
+	TEST_PAUSE;
+}
+
+static void verify_read(void)
+{
+	char buf[255];
+
+	TEST(read(fd, buf, sizeof(buf)));
+	check_result("read(2)");
+}
+
+static void verify_write(void)
+{
+	TEST(write(fd, "w", 1));
+	check_result("write(2)");
+}
+
+static void verify_fchmod(void)
+{
+	TEST(fchmod(fd, 0666));
+	check_result("fchmod(2)");
+}
+
+static void verify_fchown(void)
+{
+	TEST(fchown(fd, 1000, 1000));
+	check_result("fchown(2)");
+}
+
+#ifdef HAVE_SYS_XATTR_H
+static void verify_fgetxattr(void)
+{
+	TEST(fgetxattr(fd, "tkey", NULL, 1));
+	check_result("fgetxattr(2)");
+}
+#endif
+
+static void check_result(const char *call_name)
+{
+	if (TEST_RETURN == 0) {
+		tst_resm(TFAIL, "%s succeeded unexpectedly", call_name);
+		return;
+	}
+
+	if (TEST_ERRNO != EBADF) {
+		tst_resm(TFAIL | TTERRNO, "%s failed unexpectedly, "
+			"expected EBADF", call_name);
+		return;
+	}
+
+	tst_resm(TPASS, "%s failed with EBADF", call_name);
+}
+
+static void cleanup(void)
+{
+	if (fd > 0 && close(fd))
+		tst_resm(TWARN | TERRNO, "failed to close file");
+
+	tst_rmdir();
+}

--- a/ltp_src/testcases/kernel/syscalls/read/read03_run.c
+++ b/ltp_src/testcases/kernel/syscalls/read/read03_run.c
@@ -1,0 +1,149 @@
+/*
+ *
+ *   Copyright (c) International Business Machines  Corp., 2001
+ *
+ *   This program is free software;  you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *   the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program;  if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * NAME
+ *	read03.c
+ *
+ * DESCRIPTION
+ *	Testcase to check that read() sets errno to EAGAIN
+ *
+ * ALGORITHM
+ *	Create a named pipe (fifo), open it in O_NONBLOCK mode, and
+ *	attempt to read from it, without writing to it. read() should fail
+ *	with EAGAIN.
+ *
+ * USAGE:  <for command-line>
+ *  read03 [-c n] [-e] [-i n] [-I x] [-P x] [-t]
+ *     where,  -c n : Run n copies concurrently.
+ *             -e   : Turn on errno logging.
+ *             -i n : Execute test n times.
+ *             -I x : Execute test for x seconds.
+ *             -P x : Pause for x seconds between iterations.
+ *             -t   : Turn on syscall timing.
+ *
+ * HISTORY
+ *	07/2001 Ported by Wayne Boyer
+ *
+ * RESTRICTIONS
+ *	NONE
+ */
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <errno.h>
+#include "test.h"
+
+#define DIR_NAME "/tmp"
+char *TCID = "read03";
+int TST_TOTAL = 1;
+
+char fifo[100] = "read03_fifo";
+int rfd, wfd;
+struct stat buf;
+
+void alarm_handler();
+void setup();
+void cleanup();
+
+int main(int ac, char **av)
+{
+	int lc;
+
+	int c;
+
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	setup();
+
+	/*
+	 * The following loop checks looping state if -i option given
+	 */
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+		/* reset tst_count in case we are looping */
+		tst_count = 0;
+
+		TEST(read(rfd, &c, 1));
+
+		if (TEST_RETURN != -1) {
+			tst_resm(TFAIL, "read() failed to fail when nothing "
+				 "is written to a pipe");
+			continue;
+		}
+
+		if (TEST_ERRNO != EAGAIN) {
+			tst_resm(TFAIL, "read set bad errno, expected "
+				 "EAGAIN, got %d", TEST_ERRNO);
+		} else {
+			tst_resm(TPASS, "read() succeded in setting errno to "
+				 "EAGAIN");
+		}
+	}
+	cleanup();
+	tst_exit();
+
+}
+
+/*
+ * setup() - performs all ONE TIME setup for this test
+ */
+void setup(void)
+{
+
+	// tst_sig(NOFORK, DEF_HANDLER, cleanup);
+
+	// TEST_PAUSE;
+
+	// /* create a temporary filename */
+	// sprintf(fifo, "%s.%d", fifo, getpid());
+
+	/* Create a temporary directory and cd to it */
+	// tst_tmpdir();
+
+    chdir(DIR_NAME);
+
+	// if (mknod(fifo, S_IFIFO | 0777, 0) < 0) {
+	// 	tst_brkm(TBROK, cleanup, "mknod() failed, errno: %d", errno);
+	// }
+	// if (stat(fifo, &buf) != 0) {
+	// 	tst_brkm(TBROK, cleanup, "stat() failed, errno: %d", errno);
+	// }
+	// if ((buf.st_mode & S_IFIFO) == 0) {
+	// 	tst_brkm(TBROK, cleanup, "Mode does not indicate fifo file");
+	// }
+
+	rfd = open(fifo, O_RDONLY | O_NONBLOCK);
+	wfd = open(fifo, O_WRONLY | O_NONBLOCK);
+}
+
+/*
+ * cleanup() - performs all ONE TIME cleanup for this test at
+ *	       completion or premature exit.
+ */
+void cleanup(void)
+{
+
+	close(rfd);
+	close(wfd);
+	unlink(fifo);
+
+	/* delete the test directory created in setup() */
+	tst_rmdir();
+
+}

--- a/ltp_src/testcases/kernel/syscalls/read/read03_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/read/read03_setup.c
@@ -1,0 +1,149 @@
+/*
+ *
+ *   Copyright (c) International Business Machines  Corp., 2001
+ *
+ *   This program is free software;  you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *   the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program;  if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * NAME
+ *	read03.c
+ *
+ * DESCRIPTION
+ *	Testcase to check that read() sets errno to EAGAIN
+ *
+ * ALGORITHM
+ *	Create a named pipe (fifo), open it in O_NONBLOCK mode, and
+ *	attempt to read from it, without writing to it. read() should fail
+ *	with EAGAIN.
+ *
+ * USAGE:  <for command-line>
+ *  read03 [-c n] [-e] [-i n] [-I x] [-P x] [-t]
+ *     where,  -c n : Run n copies concurrently.
+ *             -e   : Turn on errno logging.
+ *             -i n : Execute test n times.
+ *             -I x : Execute test for x seconds.
+ *             -P x : Pause for x seconds between iterations.
+ *             -t   : Turn on syscall timing.
+ *
+ * HISTORY
+ *	07/2001 Ported by Wayne Boyer
+ *
+ * RESTRICTIONS
+ *	NONE
+ */
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <errno.h>
+#include "test.h"
+
+#define DIR_NAME "/tmp"
+char *TCID = "read03";
+int TST_TOTAL = 1;
+
+char fifo[100] = "read03_fifo";
+int rfd, wfd;
+struct stat buf;
+
+void alarm_handler();
+void setup();
+void cleanup();
+
+int main(int ac, char **av)
+{
+	int lc;
+
+	int c;
+
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	setup();
+
+	// /*
+	//  * The following loop checks looping state if -i option given
+	//  */
+	// for (lc = 0; TEST_LOOPING(lc); lc++) {
+	// 	/* reset tst_count in case we are looping */
+	// 	tst_count = 0;
+
+	// 	TEST(read(rfd, &c, 1));
+
+	// 	if (TEST_RETURN != -1) {
+	// 		tst_resm(TFAIL, "read() failed to fail when nothing "
+	// 			 "is written to a pipe");
+	// 		continue;
+	// 	}
+
+	// 	if (TEST_ERRNO != EAGAIN) {
+	// 		tst_resm(TFAIL, "read set bad errno, expected "
+	// 			 "EAGAIN, got %d", TEST_ERRNO);
+	// 	} else {
+	// 		tst_resm(TPASS, "read() succeded in setting errno to "
+	// 			 "EAGAIN");
+	// 	}
+	// }
+	// cleanup();
+	// tst_exit();
+
+}
+
+/*
+ * setup() - performs all ONE TIME setup for this test
+ */
+void setup(void)
+{
+
+	tst_sig(NOFORK, DEF_HANDLER, cleanup);
+
+	TEST_PAUSE;
+
+	/* create a temporary filename */
+	// sprintf(fifo, "%s.%d", fifo, getpid());
+
+	/* Create a temporary directory and cd to it */
+	// tst_tmpdir();
+
+    chdir(DIR_NAME);
+
+	if (mknod(fifo, S_IFIFO | 0777, 0) < 0) {
+		tst_brkm(TBROK, cleanup, "mknod() failed, errno: %d", errno);
+	}
+	if (stat(fifo, &buf) != 0) {
+		tst_brkm(TBROK, cleanup, "stat() failed, errno: %d", errno);
+	}
+	if ((buf.st_mode & S_IFIFO) == 0) {
+		tst_brkm(TBROK, cleanup, "Mode does not indicate fifo file");
+	}
+
+	// rfd = open(fifo, O_RDONLY | O_NONBLOCK);
+	// wfd = open(fifo, O_WRONLY | O_NONBLOCK);
+}
+
+/*
+ * cleanup() - performs all ONE TIME cleanup for this test at
+ *	       completion or premature exit.
+ */
+void cleanup(void)
+{
+
+	// close(rfd);
+	// close(wfd);
+	// unlink(fifo);
+
+	// /* delete the test directory created in setup() */
+	// tst_rmdir();
+
+}

--- a/ltp_src/testcases/kernel/syscalls/readlink/readlink01_run.c
+++ b/ltp_src/testcases/kernel/syscalls/readlink/readlink01_run.c
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) International Business Machines Corp., 2001
+ * Ported to LTP: Wayne Boyer
+ */
+
+/*
+ * Test Description :
+ *   Testcase to check the basic functionality of the readlink(2),
+ *   readlink() will succeed to read the contents of the symbolic link.
+ */
+
+#include <pwd.h>
+#include <errno.h>
+#include <string.h>
+
+#include "tst_test.h"
+
+#define TESTFILE "/tmp/test_file"
+#define SYMFILE	"/tmp/slink_file"
+
+static uid_t nobody_uid;
+
+static void test_readlink(void)
+{
+	char buffer[256];
+	int exp_val = strlen(TESTFILE);
+
+	TEST(readlink(SYMFILE, buffer, sizeof(buffer)));
+	if (TST_RET == -1) {
+		tst_res(TFAIL | TTERRNO, "readlink() on %s failed", SYMFILE);
+		return;
+	}
+
+	if (TST_RET != exp_val) {
+		tst_res(TFAIL, "readlink() returned value %ld "
+			"did't match, Expected %d", TST_RET, exp_val);
+		return;
+	}
+
+	if (memcmp(buffer, TESTFILE, exp_val) != 0) {
+		tst_res(TFAIL, "Pathname %s and buffer contents %s differ",
+			TESTFILE, buffer);
+	} else {
+		tst_res(TPASS, "readlink() functionality on '%s' was correct",
+			SYMFILE);
+	}
+}
+
+static void verify_readlink(unsigned int n)
+{
+	pid_t pid;
+
+	if (n) {
+		tst_res(TINFO, "Running test as nobody");
+		pid = SAFE_FORK();
+
+		if (!pid) {
+			SAFE_SETUID(nobody_uid);
+			test_readlink();
+			return;
+		}
+	} else {
+		tst_res(TINFO, "Running test as root");
+		test_readlink();
+	}
+}
+
+static void setup(void)
+{
+	// int fd;
+	struct passwd *pw;
+
+	pw = SAFE_GETPWNAM("nobody");
+
+	nobody_uid = pw->pw_uid;
+
+	// fd = SAFE_OPEN(TESTFILE, O_RDWR | O_CREAT, 0444);
+	// SAFE_CLOSE(fd);
+	// SAFE_SYMLINK(TESTFILE, SYMFILE);
+}
+
+static struct tst_test test = {
+	.test = verify_readlink,\
+	.tcnt = 2,
+	.setup = setup,
+	.forks_child = 1,
+	.needs_root = 1,
+	.needs_tmpdir = 1,
+};

--- a/ltp_src/testcases/kernel/syscalls/readlink/readlink01_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/readlink/readlink01_setup.c
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) International Business Machines Corp., 2001
+ * Ported to LTP: Wayne Boyer
+ */
+
+/*
+ * Test Description :
+ *   Testcase to check the basic functionality of the readlink(2),
+ *   readlink() will succeed to read the contents of the symbolic link.
+ */
+
+#include <pwd.h>
+#include <errno.h>
+#include <string.h>
+
+#include "tst_test.h"
+
+#define TESTFILE "/tmp/test_file"
+#define SYMFILE	"/tmp/slink_file"
+
+static uid_t nobody_uid;
+
+static void test_readlink(void)
+{
+    tst_res(TPASS, "No test function here");
+	// char buffer[256];
+	// int exp_val = strlen(TESTFILE);
+
+	// TEST(readlink(SYMFILE, buffer, sizeof(buffer)));
+	// if (TST_RET == -1) {
+	// 	tst_res(TFAIL | TTERRNO, "readlink() on %s failed", SYMFILE);
+	// 	return;
+	// }
+
+	// if (TST_RET != exp_val) {
+	// 	tst_res(TFAIL, "readlink() returned value %ld "
+	// 		"did't match, Expected %d", TST_RET, exp_val);
+	// 	return;
+	// }
+
+	// if (memcmp(buffer, TESTFILE, exp_val) != 0) {
+	// 	tst_res(TFAIL, "Pathname %s and buffer contents %s differ",
+	// 		TESTFILE, buffer);
+	// } else {
+	// 	tst_res(TPASS, "readlink() functionality on '%s' was correct",
+	// 		SYMFILE);
+	// }
+}
+
+static void verify_readlink(unsigned int n)
+{
+    tst_res(TPASS, "No test function here");
+	// pid_t pid;
+
+	// if (n) {
+	// 	tst_res(TINFO, "Running test as nobody");
+	// 	pid = SAFE_FORK();
+
+	// 	if (!pid) {
+	// 		SAFE_SETUID(nobody_uid);
+	// 		test_readlink();
+	// 		return;
+	// 	}
+	// } else {
+	// 	tst_res(TINFO, "Running test as root");
+	// 	test_readlink();
+	// }
+}
+
+static void setup(void)
+{
+	int fd;
+	struct passwd *pw;
+
+	pw = SAFE_GETPWNAM("nobody");
+
+	nobody_uid = pw->pw_uid;
+
+	fd = SAFE_OPEN(TESTFILE, O_RDWR | O_CREAT, 0444);
+	SAFE_CLOSE(fd);
+	SAFE_SYMLINK(TESTFILE, SYMFILE);
+}
+
+static struct tst_test test = {
+	.test = verify_readlink,\
+	.tcnt = 2,
+	.setup = setup,
+	.forks_child = 1,
+	.needs_root = 1,
+	.needs_tmpdir = 1,
+};

--- a/ltp_src/testcases/kernel/syscalls/readlinkat/readlinkat01_run.c
+++ b/ltp_src/testcases/kernel/syscalls/readlinkat/readlinkat01_run.c
@@ -1,0 +1,145 @@
+/******************************************************************************
+ *
+ * Copyright (c) International Business Machines  Corp., 2006
+ *  Author: Yi Yang <yyangcdl@cn.ibm.com>
+ * Copyright (c) Cyril Hrubis 2014 <chrubis@suse.cz>
+ *
+ * This program is free software;  you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program;  if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ * This test case will verify basic function of readlinkat
+ * added by kernel 2.6.16 or up.
+ *
+ *****************************************************************************/
+
+#define _GNU_SOURCE
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include <signal.h>
+#include "test.h"
+#include "safe_macros.h"
+#include "lapi/readlinkat.h"
+
+static void setup(void);
+static void cleanup(void);
+
+char *TCID = "readlinkat01";
+
+static int dir_fd, fd;
+static int fd_invalid = 100;
+static int fd_atcwd = AT_FDCWD;
+
+#define TEST_SYMLINK "readlink_symlink"
+#define TEST_FILE "readlink_file"
+#define DIR_NAME "/tmp"
+
+static char abspath[1024];
+
+static struct test_case {
+	int *dir_fd;
+	const char *path;
+	const char *exp_buf;
+	int exp_ret;
+	int exp_errno;
+} test_cases[] = {
+	{&dir_fd, TEST_SYMLINK, TEST_FILE, sizeof(TEST_FILE)-1, 0},
+	{&dir_fd, abspath, TEST_FILE, sizeof(TEST_FILE)-1, 0},
+	{&fd, TEST_SYMLINK, NULL, -1, ENOTDIR},
+	{&fd_invalid, TEST_SYMLINK, NULL, -1, EBADF},
+	{&fd_atcwd, TEST_SYMLINK, TEST_FILE, sizeof(TEST_FILE)-1, 0},
+};
+
+int TST_TOTAL = ARRAY_SIZE(test_cases);
+
+static void verify_readlinkat(struct test_case *test)
+{
+	char buf[1024];
+
+	memset(buf, 0, sizeof(buf));
+
+	TEST(readlinkat(*test->dir_fd, test->path, buf, sizeof(buf)));
+
+	if (TEST_RETURN != test->exp_ret) {
+		tst_resm(TFAIL | TTERRNO,
+		         "readlinkat() returned %ld, expected %d",
+		         TEST_RETURN, test->exp_ret);
+		return;
+	}
+
+	if (TEST_ERRNO != test->exp_errno) {
+		tst_resm(TFAIL | TTERRNO,
+		         "readlinkat() returned %ld, expected %d",
+		         TEST_RETURN, test->exp_ret);
+		return;
+	}
+
+	if (test->exp_ret > 0 && strcmp(test->exp_buf, buf)) {
+		tst_resm(TFAIL, "Unexpected buffer have '%s', expected '%s'",
+		         buf, test->exp_buf);
+		return;
+	}
+
+	tst_resm(TPASS | TTERRNO, "readlinkat() returned %ld", TEST_RETURN);
+}
+
+int main(int ac, char **av)
+{
+	int lc;
+	int i;
+
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	setup();
+
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+		for (i = 0; i < TST_TOTAL; i++)
+			verify_readlinkat(&test_cases[i]);
+	}
+
+	cleanup();
+	tst_exit();
+}
+
+static void setup(void)
+{
+	// tst_tmpdir();
+	// char *tmpdir = tst_get_tmpdir();
+    SAFE_CHDIR(cleanup, DIR_NAME);
+	snprintf(abspath, sizeof(abspath), "%s/" TEST_SYMLINK, DIR_NAME);
+    tst_resm(TINFO, "abspath is %s", abspath);
+	// free(tmpdir);
+
+	fd = SAFE_OPEN(cleanup, TEST_FILE, O_CREAT, 0600);
+	// SAFE_SYMLINK(cleanup, TEST_FILE, TEST_SYMLINK);
+	dir_fd = SAFE_OPEN(cleanup, DIR_NAME, O_DIRECTORY);
+
+	TEST_PAUSE;
+}
+
+static void cleanup(void)
+{
+	if (fd > 0 && close(fd))
+		tst_resm(TWARN | TERRNO, "Failed to close fd");
+
+	if (dir_fd > 0 && close(dir_fd))
+		tst_resm(TWARN | TERRNO, "Failed to close dir_fd");
+
+	// tst_rmdir();
+}

--- a/ltp_src/testcases/kernel/syscalls/readlinkat/readlinkat01_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/readlinkat/readlinkat01_setup.c
@@ -1,0 +1,144 @@
+/******************************************************************************
+ *
+ * Copyright (c) International Business Machines  Corp., 2006
+ *  Author: Yi Yang <yyangcdl@cn.ibm.com>
+ * Copyright (c) Cyril Hrubis 2014 <chrubis@suse.cz>
+ *
+ * This program is free software;  you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program;  if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ * This test case will verify basic function of readlinkat
+ * added by kernel 2.6.16 or up.
+ *
+ *****************************************************************************/
+
+#define _GNU_SOURCE
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include <signal.h>
+#include "test.h"
+#include "safe_macros.h"
+#include "lapi/readlinkat.h"
+
+static void setup(void);
+static void cleanup(void);
+
+char *TCID = "readlinkat01";
+
+static int dir_fd, fd;
+static int fd_invalid = 100;
+static int fd_atcwd = AT_FDCWD;
+
+#define TEST_SYMLINK "readlink_symlink"
+#define TEST_FILE "readlink_file"
+#define DIR_NAME "/tmp"
+
+static char abspath[1024];
+
+static struct test_case {
+	int *dir_fd;
+	const char *path;
+	const char *exp_buf;
+	int exp_ret;
+	int exp_errno;
+} test_cases[] = {
+	{&dir_fd, TEST_SYMLINK, TEST_FILE, sizeof(TEST_FILE)-1, 0},
+	{&dir_fd, abspath, TEST_FILE, sizeof(TEST_FILE)-1, 0},
+	{&fd, TEST_SYMLINK, NULL, -1, ENOTDIR},
+	{&fd_invalid, TEST_SYMLINK, NULL, -1, EBADF},
+	{&fd_atcwd, TEST_SYMLINK, TEST_FILE, sizeof(TEST_FILE)-1, 0},
+};
+
+int TST_TOTAL = ARRAY_SIZE(test_cases);
+
+static void verify_readlinkat(struct test_case *test)
+{
+    tst_resm(TPASS, "No test function here");
+	// char buf[1024];
+
+	// memset(buf, 0, sizeof(buf));
+
+	// TEST(readlinkat(*test->dir_fd, test->path, buf, sizeof(buf)));
+
+	// if (TEST_RETURN != test->exp_ret) {
+	// 	tst_resm(TFAIL | TTERRNO,
+	// 	         "readlinkat() returned %ld, expected %d",
+	// 	         TEST_RETURN, test->exp_ret);
+	// 	return;
+	// }
+
+	// if (TEST_ERRNO != test->exp_errno) {
+	// 	tst_resm(TFAIL | TTERRNO,
+	// 	         "readlinkat() returned %ld, expected %d",
+	// 	         TEST_RETURN, test->exp_ret);
+	// 	return;
+	// }
+
+	// if (test->exp_ret > 0 && strcmp(test->exp_buf, buf)) {
+	// 	tst_resm(TFAIL, "Unexpected buffer have '%s', expected '%s'",
+	// 	         buf, test->exp_buf);
+	// 	return;
+	// }
+
+	// tst_resm(TPASS | TTERRNO, "readlinkat() returned %ld", TEST_RETURN);
+}
+
+int main(int ac, char **av)
+{
+	int lc;
+	int i;
+
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	setup();
+
+	// for (lc = 0; TEST_LOOPING(lc); lc++) {
+	// 	for (i = 0; i < TST_TOTAL; i++)
+	// 		verify_readlinkat(&test_cases[i]);
+	// }
+
+	// cleanup();
+	// tst_exit();
+}
+
+static void setup(void)
+{
+	// tst_tmpdir();
+	// char *tmpdir = tst_get_tmpdir();
+
+    SAFE_CHDIR(cleanup, DIR_NAME);
+	snprintf(abspath, sizeof(abspath), "%s/" TEST_SYMLINK, DIR_NAME);
+	// free(tmpdir);
+    tst_resm(TINFO, "abspath is %s", abspath);
+	fd = SAFE_OPEN(cleanup, TEST_FILE, O_CREAT, 0600);
+	SAFE_SYMLINK(cleanup, TEST_FILE, TEST_SYMLINK);
+	dir_fd = SAFE_OPEN(cleanup, DIR_NAME, O_DIRECTORY);
+}
+
+static void cleanup(void)
+{
+	// if (fd > 0 && close(fd))
+	// 	tst_resm(TWARN | TERRNO, "Failed to close fd");
+
+	// if (dir_fd > 0 && close(dir_fd))
+	// 	tst_resm(TWARN | TERRNO, "Failed to close dir_fd");
+
+	// tst_rmdir();
+}

--- a/ltp_src/testcases/kernel/syscalls/readlinkat/readlinkat02_run.c
+++ b/ltp_src/testcases/kernel/syscalls/readlinkat/readlinkat02_run.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2014 Fujitsu Ltd.
+ * Author: Zeng Linggang <zenglg.jy@cn.fujitsu.com>
+ *
+ * This program is free software;  you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ */
+/*
+ * Test Description:
+ *  Verify that,
+ *   1. bufsiz is 0, EINVAL should be returned.
+ *   2. The named file is not a symbolic link, EINVAL should be returned.
+ *   3. The component of the path prefix is not a directory, ENOTDIR should be
+ *	returned.
+ *   4. pathname is relative and dirfd is a file descriptor referring to a file
+ *	other than a directory, ENOTDIR should be returned.
+ */
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include "test.h"
+#include "safe_macros.h"
+#include "lapi/readlinkat.h"
+#include "lapi/syscalls.h"
+
+#define TEST_FILE	"test_file"
+#define SYMLINK_FILE	"symlink_file"
+#define DIR_NAME "/tmp"
+// #define DIR_TEMP "/tmp/readlinkat_dir"
+#define BUFF_SIZE	256
+
+static int file_fd, dir_fd;
+
+static struct test_case_t {
+	int *dirfd;
+	const char *pathname;
+	size_t bufsiz;
+	int exp_errno;
+} test_cases[] = {
+	{&dir_fd, SYMLINK_FILE, 0, EINVAL},
+	{&dir_fd, TEST_FILE, BUFF_SIZE, EINVAL},
+	{&file_fd, SYMLINK_FILE, BUFF_SIZE, ENOTDIR},
+	{&dir_fd, "test_file/test_file", BUFF_SIZE, ENOTDIR},
+};
+
+char *TCID = "readlinkat02";
+int TST_TOTAL = ARRAY_SIZE(test_cases);
+static void setup(void);
+static void cleanup(void);
+static void readlinkat_verify(const struct test_case_t *);
+
+int main(int argc, char **argv)
+{
+	int i, lc;
+
+	tst_parse_opts(argc, argv, NULL, NULL);
+
+	setup();
+
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+		tst_count = 0;
+		for (i = 0; i < TST_TOTAL; i++)
+			readlinkat_verify(&test_cases[i]);
+	}
+
+	cleanup();
+	tst_exit();
+}
+
+static void setup(void)
+{
+	// tst_sig(NOFORK, DEF_HANDLER, cleanup);
+
+	// TEST_PAUSE;
+
+	// tst_tmpdir();
+    // SAFE_MKDIR(cleanup, DIR_TEMP, 0777);
+    SAFE_CHDIR(cleanup, DIR_NAME);
+    tst_resm(TINFO, "In setup");
+	dir_fd = SAFE_OPEN(cleanup, DIR_NAME, O_RDONLY);
+
+	file_fd = SAFE_OPEN(cleanup, TEST_FILE, O_RDWR | O_CREAT, 0644);
+
+	// SAFE_SYMLINK(cleanup, TEST_FILE, SYMLINK_FILE);
+}
+
+static void readlinkat_verify(const struct test_case_t *test)
+{
+	char buf[BUFF_SIZE];
+	TEST(readlinkat(*test->dirfd, test->pathname, buf, test->bufsiz));
+
+	if (TEST_RETURN != -1) {
+		tst_resm(TFAIL, "readlinkat succeeded unexpectedly");
+		return;
+	}
+
+	if (TEST_ERRNO == test->exp_errno) {
+		tst_resm(TPASS | TTERRNO, "readlinkat failed as expected");
+	} else {
+		tst_resm(TFAIL | TTERRNO,
+			 "readlinkat failed unexpectedly; expected: %d - %s",
+			 test->exp_errno, strerror(test->exp_errno));
+	}
+}
+
+static void cleanup(void)
+{
+	close(dir_fd);
+	close(file_fd);
+
+	// tst_rmdir();
+}

--- a/ltp_src/testcases/kernel/syscalls/readlinkat/readlinkat02_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/readlinkat/readlinkat02_setup.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2014 Fujitsu Ltd.
+ * Author: Zeng Linggang <zenglg.jy@cn.fujitsu.com>
+ *
+ * This program is free software;  you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ */
+/*
+ * Test Description:
+ *  Verify that,
+ *   1. bufsiz is 0, EINVAL should be returned.
+ *   2. The named file is not a symbolic link, EINVAL should be returned.
+ *   3. The component of the path prefix is not a directory, ENOTDIR should be
+ *	returned.
+ *   4. pathname is relative and dirfd is a file descriptor referring to a file
+ *	other than a directory, ENOTDIR should be returned.
+ */
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include "test.h"
+#include "safe_macros.h"
+#include "lapi/readlinkat.h"
+#include "lapi/syscalls.h"
+
+#define TEST_FILE	"/tmp/test_file"
+#define SYMLINK_FILE	"/tmp/symlink_file"
+#define DIR_NAME "/tmp"
+// #define DIR_TEMP "/tmp/readlinkat_dir"
+#define BUFF_SIZE	256
+
+static int file_fd, dir_fd;
+
+static struct test_case_t {
+	int *dirfd;
+	const char *pathname;
+	size_t bufsiz;
+	int exp_errno;
+} test_cases[] = {
+	{&dir_fd, SYMLINK_FILE, 0, EINVAL},
+	{&dir_fd, TEST_FILE, BUFF_SIZE, EINVAL},
+	{&file_fd, SYMLINK_FILE, BUFF_SIZE, ENOTDIR},
+	{&dir_fd, "test_file/test_file", BUFF_SIZE, ENOTDIR},
+};
+
+char *TCID = "readlinkat02";
+int TST_TOTAL = ARRAY_SIZE(test_cases);
+static void setup(void);
+static void cleanup(void);
+static void readlinkat_verify(const struct test_case_t *);
+
+int main(int argc, char **argv)
+{
+	int i, lc;
+
+	tst_parse_opts(argc, argv, NULL, NULL);
+
+	setup();
+
+	// for (lc = 0; TEST_LOOPING(lc); lc++) {
+	// 	tst_count = 0;
+	// 	for (i = 0; i < TST_TOTAL; i++)
+	// 		readlinkat_verify(&test_cases[i]);
+	// }
+
+	// cleanup();
+	// tst_exit();
+}
+
+static void setup(void)
+{
+	tst_sig(NOFORK, DEF_HANDLER, cleanup);
+
+	TEST_PAUSE;
+
+	// tst_tmpdir();
+    // SAFE_MKDIR(cleanup, DIR_TEMP, 0777);
+	SAFE_CHDIR(cleanup, DIR_NAME);
+	dir_fd = SAFE_OPEN(cleanup, DIR_NAME, O_RDONLY);
+
+	file_fd = SAFE_OPEN(cleanup, TEST_FILE, O_RDWR | O_CREAT, 0644);
+
+	SAFE_SYMLINK(cleanup, TEST_FILE, SYMLINK_FILE);
+}
+
+static void readlinkat_verify(const struct test_case_t *test)
+{
+	// char buf[BUFF_SIZE];
+	// TEST(readlinkat(*test->dirfd, test->pathname, buf, test->bufsiz));
+
+	// if (TEST_RETURN != -1) {
+	// 	tst_resm(TFAIL, "readlinkat succeeded unexpectedly");
+	// 	return;
+	// }
+
+	// if (TEST_ERRNO == test->exp_errno) {
+	// 	tst_resm(TPASS | TTERRNO, "readlinkat failed as expected");
+	// } else {
+	// 	tst_resm(TFAIL | TTERRNO,
+	// 		 "readlinkat failed unexpectedly; expected: %d - %s",
+	// 		 test->exp_errno, strerror(test->exp_errno));
+	// }
+}
+
+static void cleanup(void)
+{
+	// close(dir_fd);
+	// close(file_fd);
+
+	// tst_rmdir();
+}

--- a/ltp_src/testcases/kernel/syscalls/rename/rename01_run.c
+++ b/ltp_src/testcases/kernel/syscalls/rename/rename01_run.c
@@ -1,0 +1,198 @@
+/*
+ *
+ *   Copyright (c) International Business Machines  Corp., 2001
+ *
+ *   This program is free software;  you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *   the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program;  if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * NAME
+ *	rename01
+ *
+ * DESCRIPTION
+ *	This test will verify the rename(2) syscall basic functionality.
+ *	Verify rename() works when the "new" file or directory does not exist.
+ *
+ * ALGORITHM
+ *	Setup:
+ *		Setup signal handling.
+ *		Create temporary directory.
+ *		Pause for SIGUSR1 if option specified.
+ *
+ *	Test:
+ *		Loop if the proper options are given.
+ *              1.  "old" is plain file, new does not exists
+ *                  create the "old" file, make sure the "new" file
+ *                  dose not exist
+ *                  rename the "old" to the "new" file
+ *                  verify the "new" file points to the "old" file
+ *                  verify the "old" file does not exist
+ *
+ *              2.  "old" is a directory,"new" does not exists
+ *                  create the "old" directory, make sure "new"
+ *                  dose not exist
+ *                  rename the "old" to the "new"
+ *                  verify the "new" points to the "old"
+ *                  verify the "old" does not exist
+ *	Cleanup:
+ *		Print errno log and/or timing stats if options given
+ *		Delete the temporary directory created.
+ *
+ * USAGE
+ *	rename01 [-c n] [-f] [-i n] [-I x] [-P x] [-t]
+ *	where,  -c n : Run n copies concurrently.
+ *		-f   : Turn off functionality Testing.
+ *		-i n : Execute test n times.
+ *		-I x : Execute test for x seconds.
+ *		-P x : Pause for x seconds between iterations.
+ *		-t   : Turn on syscall timing.
+ *
+ * HISTORY
+ *	07/2001 Ported by Wayne Boyer
+ *
+ * RESTRICTIONS
+ *	None.
+ */
+#include <sys/types.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include "test.h"
+#include "safe_macros.h"
+
+void setup();
+void cleanup();
+
+char *TCID = "rename01";
+int TST_TOTAL = 2;
+
+char fname[255] = "/tmp/rename01_fname";
+char mname[255] = "/tmp/rename01_mname";
+char fdir[255] = "/tmp/rename01_fdir";
+char mdir[255] = "/tmp/rename01_mdir";
+struct stat buf1;
+dev_t f_olddev, d_olddev;
+ino_t f_oldino, d_oldino;
+
+struct test_case_t {
+	char *name1;
+	char *name2;
+	char *desc;
+	dev_t *olddev;
+	ino_t *oldino;
+} TC[] = {
+	/* comment goes here */
+	{
+	fname, mname, "file", &f_olddev, &f_oldino},
+	    /* comment goes here */
+	{
+	fdir, mdir, "directory", &d_olddev, &d_oldino}
+};
+
+int main(int ac, char **av)
+{
+	int lc;
+	int i;
+
+	/*
+	 * parse standard options
+	 */
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	/*
+	 * perform global setup for test
+	 */
+	setup();
+
+	/*
+	 * check looping state if -i option given
+	 */
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+
+		tst_count = 0;
+
+		/* loop through the test cases */
+		for (i = 0; i < TST_TOTAL; i++) {
+
+			TEST(rename(TC[i].name1, TC[i].name2));
+
+			if (TEST_RETURN == -1) {
+				tst_resm(TFAIL, "call failed unexpectedly");
+				continue;
+			}
+
+			SAFE_STAT(cleanup, TC[i].name2, &buf1);
+
+			/*
+			 * verify the new file or directory is the
+			 * same as the old one
+			 */
+			
+			if (buf1.st_dev != *TC[i].olddev ||
+			    buf1.st_ino != *TC[i].oldino) {
+				tst_resm(TFAIL, "rename() failed: the "
+					 "new %s points to a different "
+					 "inode/location", TC[i].desc);
+				continue;
+			}	
+
+			/*
+			 * verify that the old file or directory
+			 * does not exist
+			 */
+			if (stat(fname, &buf1) != -1) {
+				tst_resm(TFAIL, "the old %s still "
+					 "exists", TC[i].desc);
+				continue;
+			}
+
+			tst_resm(TPASS, "functionality is correct "
+				 "for renaming a %s", TC[i].desc);
+		}
+		/* reset things in case we are looping */
+		// SAFE_RENAME(cleanup, mname, fname);
+
+		// SAFE_RENAME(cleanup, mdir, fdir);
+	}
+
+	cleanup();
+	tst_exit();
+}
+
+/*
+ * setup() - performs all ONE TIME setup for this test.
+ */
+void setup(void)
+{
+
+	SAFE_STAT(cleanup, fname, &buf1);
+
+	f_olddev = buf1.st_dev;
+	f_oldino = buf1.st_ino;
+
+	SAFE_STAT(cleanup, fdir, &buf1);
+
+	d_olddev = buf1.st_dev;
+	d_oldino = buf1.st_ino;
+}
+
+/*
+ * cleanup() - performs all ONE TIME cleanup for this test at
+ *             completion or premature exit.
+ */
+void cleanup(void)
+{}

--- a/ltp_src/testcases/kernel/syscalls/rename/rename01_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/rename/rename01_setup.c
@@ -1,0 +1,152 @@
+/*
+ *
+ *   Copyright (c) International Business Machines  Corp., 2001
+ *
+ *   This program is free software;  you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *   the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program;  if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * NAME
+ *	rename01
+ *
+ * DESCRIPTION
+ *	This test will verify the rename(2) syscall basic functionality.
+ *	Verify rename() works when the "new" file or directory does not exist.
+ *
+ * ALGORITHM
+ *	Setup:
+ *		Setup signal handling.
+ *		Create temporary directory.
+ *		Pause for SIGUSR1 if option specified.
+ *
+ *	Test:
+ *		Loop if the proper options are given.
+ *              1.  "old" is plain file, new does not exists
+ *                  create the "old" file, make sure the "new" file
+ *                  dose not exist
+ *                  rename the "old" to the "new" file
+ *                  verify the "new" file points to the "old" file
+ *                  verify the "old" file does not exist
+ *
+ *              2.  "old" is a directory,"new" does not exists
+ *                  create the "old" directory, make sure "new"
+ *                  dose not exist
+ *                  rename the "old" to the "new"
+ *                  verify the "new" points to the "old"
+ *                  verify the "old" does not exist
+ *	Cleanup:
+ *		Print errno log and/or timing stats if options given
+ *		Delete the temporary directory created.
+ *
+ * USAGE
+ *	rename01 [-c n] [-f] [-i n] [-I x] [-P x] [-t]
+ *	where,  -c n : Run n copies concurrently.
+ *		-f   : Turn off functionality Testing.
+ *		-i n : Execute test n times.
+ *		-I x : Execute test for x seconds.
+ *		-P x : Pause for x seconds between iterations.
+ *		-t   : Turn on syscall timing.
+ *
+ * HISTORY
+ *	07/2001 Ported by Wayne Boyer
+ *
+ * RESTRICTIONS
+ *	None.
+ */
+#include <sys/types.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include "test.h"
+#include "safe_macros.h"
+
+void setup();
+void cleanup();
+
+char *TCID = "rename01";
+int TST_TOTAL = 2;
+
+char fname[255] = "/tmp/rename01_fname";
+char mname[255] = "/tmp/rename01_mname";
+char fdir[255] = "/tmp/rename01_fdir";
+char mdir[255] = "/tmp/rename01_mdir";
+struct stat buf1;
+dev_t f_olddev, d_olddev;
+ino_t f_oldino, d_oldino;
+
+struct test_case_t {
+	char *name1;
+	char *name2;
+	char *desc;
+	dev_t *olddev;
+	ino_t *oldino;
+} TC[] = {
+	/* comment goes here */
+	{fname, mname, "file", &f_olddev, &f_oldino},
+	    /* comment goes here */
+	{fdir, mdir, "directory", &d_olddev, &d_oldino}
+};
+
+int main(int ac, char **av)
+{
+	int lc;
+	int i;
+
+	/*
+	 * parse standard options
+	 */
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	/*
+	 * perform global setup for test
+	 */
+	setup();
+
+	cleanup();
+	// tst_exit();
+
+}
+
+/*
+ * setup() - performs all ONE TIME setup for this test.
+ */
+void setup(void)
+{
+
+	tst_sig(NOFORK, DEF_HANDLER, cleanup);
+
+	/* Create a temporary directory and make it current. */
+	tst_tmpdir();
+
+	SAFE_TOUCH(cleanup, fname, 0700, NULL);
+
+	/* create "old" directory */
+	SAFE_MKDIR(cleanup, fdir, 00770);
+}
+
+/*
+ * cleanup() - performs all ONE TIME cleanup for this test at
+ *             completion or premature exit.
+ */
+void cleanup(void)
+{
+
+	/*
+	 * Remove the temporary directory.
+	 */
+	tst_rmdir();
+}

--- a/ltp_src/testcases/kernel/syscalls/rename/rename02_run.c
+++ b/ltp_src/testcases/kernel/syscalls/rename/rename02_run.c
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2000 Silicon Graphics, Inc.  All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Further, this software is distributed without any warranty that it is
+ * free of the rightful claim of any third person regarding infringement
+ * or the like.  Any license provided herein, whether implied or
+ * otherwise, applies only to this software file.  Patent licenses, if
+ * any, provided herein do not apply to combinations of this program with
+ * other software, or any other product whatsoever.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Contact information: Silicon Graphics, Inc., 1600 Amphitheatre Pkwy,
+ * Mountain View, CA  94043, or:
+ *
+ * http://www.sgi.com
+ *
+ * For further information regarding this notice, see:
+ *
+ * http://oss.sgi.com/projects/GenInfo/NoticeExplan/
+ *
+ */
+/* $Id: rename02.c,v 1.8 2009/11/02 13:57:18 subrata_modak Exp $ */
+/**********************************************************
+ *
+ *    OS Test - Silicon Graphics, Inc.
+ *
+ *    TEST IDENTIFIER	: rename02
+ *
+ *    EXECUTED BY	: anyone
+ *
+ *    TEST TITLE	: Basic test for rename(2)
+ *
+ *    PARENT DOCUMENT	: usctpl01
+ *
+ *    TEST CASE TOTAL	: 1
+ *
+ *    WALL CLOCK TIME	: 1
+ *
+ *    CPU TYPES		: ALL
+ *
+ *    AUTHOR		: William Roske
+ *
+ *    CO-PILOT		: Dave Fenner
+ *
+ *    DATE STARTED	: 03/30/92
+ *
+ *    INITIAL RELEASE	: UNICOS 7.0
+ *
+ *    TEST CASES
+ *
+ * 	1.) rename(2) returns...(See Description)
+ *
+ *    INPUT SPECIFICATIONS
+ * 	The standard options for system call tests are accepted.
+ *	(See the parse_opts(3) man page).
+ *
+ *    OUTPUT SPECIFICATIONS
+ *$
+ *    DURATION
+ * 	Terminates - with frequency and infinite modes.
+ *
+ *    SIGNALS
+ * 	Uses SIGUSR1 to pause before test if option set.
+ * 	(See the parse_opts(3) man page).
+ *
+ *    RESOURCES
+ * 	None
+ *
+ *    ENVIRONMENTAL NEEDS
+ *      No run-time environmental needs.
+ *
+ *    SPECIAL PROCEDURAL REQUIREMENTS
+ * 	None
+ *
+ *    INTERCASE DEPENDENCIES
+ * 	None
+ *
+ *    DETAILED DESCRIPTION
+ *	This is a Phase I test for the rename(2) system call.  It is intended
+ *	to provide a limited exposure of the system call, for now.  It
+ *	should/will be extended when full functional tests are written for
+ *	rename(2).
+ *
+ * 	Setup:
+ * 	  Setup signal handling.
+ *	  Pause for SIGUSR1 if option specified.
+ *
+ * 	Test:
+ *	 Loop if the proper options are given.
+ * 	  Execute system call
+ *	  Check return code, if system call failed (return=-1)
+ *		Log the errno and Issue a FAIL message.
+ *	  Otherwise, Issue a PASS message.
+ *
+ * 	Cleanup:
+ * 	  Print errno log and/or timing stats if options given
+ *
+ *
+ *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#**/
+
+#include <sys/types.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+#include <signal.h>
+#include "test.h"
+
+void setup();
+void cleanup();
+
+char *TCID = "rename02";
+int TST_TOTAL = 1;
+
+int fd;
+char fname[255] = "/tmp/rename02_fname";
+char mname[255] = "/tmp/rename02_mname";
+
+int main(int ac, char **av)
+{
+	int lc;
+
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	setup();
+
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+
+		tst_count = 0;
+
+		/*
+		 * Call rename(2)
+		 */
+		TEST(rename(fname, mname));
+
+		/* check return code */
+		if (TEST_RETURN == -1) {
+			tst_resm(TFAIL, "rename(%s, %s) Failed, errno=%d : %s",
+				 fname, mname, TEST_ERRNO,
+				 strerror(TEST_ERRNO));
+		} else {
+			tst_resm(TPASS, "rename(%s, %s) returned %ld",
+				 fname, mname, TEST_RETURN);
+			if (unlink(mname) == -1) {
+				tst_resm(TWARN,
+					 "unlink(%s) Failed, errno=%d : %s",
+					 mname, errno, strerror(errno));
+			}
+		}
+	}
+
+	cleanup();
+	tst_exit();
+
+}
+
+/***************************************************************
+ * setup() - performs all ONE TIME setup for this test.
+ ***************************************************************/
+void setup(void)
+{}
+
+/***************************************************************
+ * cleanup() - performs all ONE TIME cleanup for this test at
+ *		completion or premature exit.
+ ***************************************************************/
+void cleanup(void)
+{
+}

--- a/ltp_src/testcases/kernel/syscalls/rename/rename02_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/rename/rename02_setup.c
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2000 Silicon Graphics, Inc.  All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Further, this software is distributed without any warranty that it is
+ * free of the rightful claim of any third person regarding infringement
+ * or the like.  Any license provided herein, whether implied or
+ * otherwise, applies only to this software file.  Patent licenses, if
+ * any, provided herein do not apply to combinations of this program with
+ * other software, or any other product whatsoever.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Contact information: Silicon Graphics, Inc., 1600 Amphitheatre Pkwy,
+ * Mountain View, CA  94043, or:
+ *
+ * http://www.sgi.com
+ *
+ * For further information regarding this notice, see:
+ *
+ * http://oss.sgi.com/projects/GenInfo/NoticeExplan/
+ *
+ */
+/* $Id: rename02.c,v 1.8 2009/11/02 13:57:18 subrata_modak Exp $ */
+/**********************************************************
+ *
+ *    OS Test - Silicon Graphics, Inc.
+ *
+ *    TEST IDENTIFIER	: rename02
+ *
+ *    EXECUTED BY	: anyone
+ *
+ *    TEST TITLE	: Basic test for rename(2)
+ *
+ *    PARENT DOCUMENT	: usctpl01
+ *
+ *    TEST CASE TOTAL	: 1
+ *
+ *    WALL CLOCK TIME	: 1
+ *
+ *    CPU TYPES		: ALL
+ *
+ *    AUTHOR		: William Roske
+ *
+ *    CO-PILOT		: Dave Fenner
+ *
+ *    DATE STARTED	: 03/30/92
+ *
+ *    INITIAL RELEASE	: UNICOS 7.0
+ *
+ *    TEST CASES
+ *
+ * 	1.) rename(2) returns...(See Description)
+ *
+ *    INPUT SPECIFICATIONS
+ * 	The standard options for system call tests are accepted.
+ *	(See the parse_opts(3) man page).
+ *
+ *    OUTPUT SPECIFICATIONS
+ *$
+ *    DURATION
+ * 	Terminates - with frequency and infinite modes.
+ *
+ *    SIGNALS
+ * 	Uses SIGUSR1 to pause before test if option set.
+ * 	(See the parse_opts(3) man page).
+ *
+ *    RESOURCES
+ * 	None
+ *
+ *    ENVIRONMENTAL NEEDS
+ *      No run-time environmental needs.
+ *
+ *    SPECIAL PROCEDURAL REQUIREMENTS
+ * 	None
+ *
+ *    INTERCASE DEPENDENCIES
+ * 	None
+ *
+ *    DETAILED DESCRIPTION
+ *	This is a Phase I test for the rename(2) system call.  It is intended
+ *	to provide a limited exposure of the system call, for now.  It
+ *	should/will be extended when full functional tests are written for
+ *	rename(2).
+ *
+ * 	Setup:
+ * 	  Setup signal handling.
+ *	  Pause for SIGUSR1 if option specified.
+ *
+ * 	Test:
+ *	 Loop if the proper options are given.
+ * 	  Execute system call
+ *	  Check return code, if system call failed (return=-1)
+ *		Log the errno and Issue a FAIL message.
+ *	  Otherwise, Issue a PASS message.
+ *
+ * 	Cleanup:
+ * 	  Print errno log and/or timing stats if options given
+ *
+ *
+ *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#**/
+
+#include <sys/types.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+#include <signal.h>
+#include "test.h"
+
+void setup();
+void cleanup();
+
+char *TCID = "rename02";
+int TST_TOTAL = 1;
+
+int fd;
+char fname[255] = "/tmp/rename02_fname";
+char mname[255] = "/tmp/rename02_mname";
+
+int main(int ac, char **av)
+{
+	int lc;
+
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	setup();
+	tst_resm(TPASS, "No test function defined here");
+	cleanup();
+}
+
+/***************************************************************
+ * setup() - performs all ONE TIME setup for this test.
+ ***************************************************************/
+void setup(void)
+{
+
+	tst_sig(NOFORK, DEF_HANDLER, cleanup);
+
+	TEST_PAUSE;
+
+	tst_tmpdir();
+
+	SAFE_TOUCH(cleanup, fname, 0700, NULL);
+}
+
+/***************************************************************
+ * cleanup() - performs all ONE TIME cleanup for this test at
+ *		completion or premature exit.
+ ***************************************************************/
+void cleanup(void)
+{
+	tst_rmdir();
+}

--- a/ltp_src/testcases/kernel/syscalls/rename/rename03_run.c
+++ b/ltp_src/testcases/kernel/syscalls/rename/rename03_run.c
@@ -1,0 +1,213 @@
+/*
+ *
+ *   Copyright (c) International Business Machines  Corp., 2001
+ *
+ *   This program is free software;  you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *   the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program;  if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * NAME
+ *	rename03
+ *
+ * DESCRIPTION
+ *	This test will verify that rename(2) functions correctly
+ *	when the "new" file or directory exists
+ *
+ * ALGORITHM
+ *	Setup:
+ *		Setup signal handling.
+ *		Create temporary directory.
+ *		Pause for SIGUSR1 if option specified.
+ *
+ *	Test:
+ *		Loop if the proper options are given.
+ *              1.  both old and new file exist
+ *                  create the "old" file and the "new" file
+ *                  rename the "old" to the "new" file
+ *                  verify the "new" file points to the "old" file
+ *                  verify the "old" file does not exists
+ *              2.  both old file and new directory exist
+ *                  create the "old" and the "new" directory
+ *                  rename the "old" to the "new" directory
+ *                  verify the "new" points to the "old" directory
+ *                  verify the "old" does not exists
+ *	Cleanup:
+ *		Print errno log and/or timing stats if options given
+ *		Delete the temporary directory created.
+ *
+ * USAGE
+ *	rename03 [-c n] [-f] [-i n] [-I x] [-p x] [-t]
+ *	where,  -c n : Run n copies concurrently.
+ *		-f   : Turn off functionality Testing.
+ *		-i n : Execute test n times.
+ *		-I x : Execute test for x seconds.
+ *		-P x : Pause for x seconds between iterations.
+ *		-t   : Turn on syscall timing.
+ *
+ * HISTORY
+ *	07/2001 Ported by Wayne Boyer
+ *
+ * RESTRICTIONS
+ *	None.
+ */
+#include <sys/types.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include "test.h"
+#include "safe_macros.h"
+
+void setup();
+void setup2();
+void cleanup();
+
+char *TCID = "rename03";
+int TST_TOTAL = 2;
+
+char fname[255] = "/tmp/rename03_fname";
+char mname[255] = "/tmp/rename03_mname";
+char fdir[255] = "/tmp/rename03_fdir";
+char mdir[255] = "/tmp/rename03_mdir";
+struct stat buf1, buf2;
+dev_t f_olddev, d_olddev;
+ino_t f_oldino, d_oldino;
+
+struct test_case_t {
+	char *name1;
+	char *name2;
+	char *desc;
+	dev_t *olddev;
+	ino_t *oldino;
+} TC[] = {
+	{
+	fname, mname, "file", &f_olddev, &f_oldino}, 
+	{fdir, mdir, "directory", &d_olddev, &d_oldino}
+};
+
+int main(int ac, char **av)
+{
+	int lc;
+	int i;
+
+	/*
+	 * parse standard options
+	 */
+	tst_parse_opts(ac, av, NULL, NULL);
+	/*
+	 * perform global setup for test
+	 */
+	setup();
+
+	/*
+	 * check looping state if -i option given
+	 */
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+
+		tst_count = 0;
+
+		// /* set up the files and directories for the tests */
+		// setup2();
+
+		/* loop through the test cases */
+		for (i = 0; i < TST_TOTAL; i++) {
+
+			TEST(rename(TC[i].name1, TC[i].name2));
+
+			if (TEST_RETURN == -1) {
+				tst_resm(TFAIL, "call failed unexpectedly");
+				continue;
+			}
+
+			SAFE_STAT(cleanup, TC[i].name2, &buf2);
+
+			/*
+			 * verify the new file or directory is the
+			 * same as the old one
+			 */
+
+			tst_resm(TINFO, "buf2.st_dev is 0%03o", buf2.st_dev);
+			tst_resm(TINFO, "buf2.st_ino is 0%03o", buf2.st_ino);
+
+			
+			tst_resm(TINFO, "TC.st_dev is 0%03o", *TC[i].olddev);
+			tst_resm(TINFO, "TC.st_ino is 0%03o", *TC[i].oldino);
+			if (buf2.st_dev != *TC[i].olddev ||
+			    buf2.st_ino != *TC[i].oldino) {
+				tst_resm(TFAIL, "rename() failed: the "
+					 "new %s points to a different "
+					 "inode/location", TC[i].desc);
+				continue;
+			}
+			/*
+			 * verify that the old file or directory
+			 * does not exist
+			 */
+			if (stat(fname, &buf2) != -1) {
+				tst_resm(TFAIL, "the old %s still "
+					 "exists", TC[i].desc);
+				continue;
+			}
+
+			tst_resm(TPASS, "functionality is correct "
+				 "for renaming a %s", TC[i].desc);
+		}
+
+		/* reset things in case we are looping */
+
+		/* unlink the new file */
+		// SAFE_UNLINK(cleanup, mname);
+
+		// /* remove the new directory */
+		// SAFE_RMDIR(cleanup, mdir);
+	}
+
+	// cleanup();
+	/* remove the new directory */
+	// SAFE_RMDIR(cleanup, mdir);
+	// tst_exit();
+
+}
+
+/*
+ * setup() - performs all ONE TIME setup for this test.
+ */
+void setup(void)
+{
+	SAFE_STAT(cleanup, fname, &buf1);
+
+	/* save original file's dev and ino */
+	f_olddev = buf1.st_dev;
+	f_oldino = buf1.st_ino;
+
+	SAFE_STAT(cleanup, fdir, &buf1);
+
+	d_olddev = buf1.st_dev;
+	d_oldino = buf1.st_ino;
+}
+
+/*
+ * cleanup() - performs all ONE TIME cleanup for this test at
+ *             completion or premature exit.
+ */
+void cleanup(void)
+{
+
+	/*
+	 * Remove the temporary directory.
+	 */
+	tst_rmdir();
+}

--- a/ltp_src/testcases/kernel/syscalls/rename/rename03_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/rename/rename03_setup.c
@@ -1,0 +1,153 @@
+/*
+ *
+ *   Copyright (c) International Business Machines  Corp., 2001
+ *
+ *   This program is free software;  you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *   the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program;  if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * NAME
+ *	rename03
+ *
+ * DESCRIPTION
+ *	This test will verify that rename(2) functions correctly
+ *	when the "new" file or directory exists
+ *
+ * ALGORITHM
+ *	Setup:
+ *		Setup signal handling.
+ *		Create temporary directory.
+ *		Pause for SIGUSR1 if option specified.
+ *
+ *	Test:
+ *		Loop if the proper options are given.
+ *              1.  both old and new file exist
+ *                  create the "old" file and the "new" file
+ *                  rename the "old" to the "new" file
+ *                  verify the "new" file points to the "old" file
+ *                  verify the "old" file does not exists
+ *              2.  both old file and new directory exist
+ *                  create the "old" and the "new" directory
+ *                  rename the "old" to the "new" directory
+ *                  verify the "new" points to the "old" directory
+ *                  verify the "old" does not exists
+ *	Cleanup:
+ *		Print errno log and/or timing stats if options given
+ *		Delete the temporary directory created.
+ *
+ * USAGE
+ *	rename03 [-c n] [-f] [-i n] [-I x] [-p x] [-t]
+ *	where,  -c n : Run n copies concurrently.
+ *		-f   : Turn off functionality Testing.
+ *		-i n : Execute test n times.
+ *		-I x : Execute test for x seconds.
+ *		-P x : Pause for x seconds between iterations.
+ *		-t   : Turn on syscall timing.
+ *
+ * HISTORY
+ *	07/2001 Ported by Wayne Boyer
+ *
+ * RESTRICTIONS
+ *	None.
+ */
+#include <sys/types.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include "test.h"
+#include "safe_macros.h"
+
+void setup();
+void setup2();
+void cleanup();
+
+char *TCID = "rename03";
+int TST_TOTAL = 2;
+
+char fname[255] = "/tmp/rename03_fname";
+char mname[255] = "/tmp/rename03_mname";
+char fdir[255] = "/tmp/rename03_fdir";
+char mdir[255] = "/tmp/rename03_mdir";
+struct stat buf1, buf2;
+dev_t f_olddev, d_olddev;
+ino_t f_oldino, d_oldino;
+
+struct test_case_t {
+	char *name1;
+	char *name2;
+	char *desc;
+	dev_t *olddev;
+	ino_t *oldino;
+} TC[] = {
+	{
+	fname, mname, "file", &f_olddev, &f_oldino}, 
+	{fdir, mdir, "directory", &d_olddev, &d_oldino}
+};
+
+int main(int ac, char **av)
+{
+	int lc;
+	int i;
+
+	/*
+	 * parse standard options
+	 */
+	tst_parse_opts(ac, av, NULL, NULL);
+	/*
+	 * perform global setup for test
+	 */
+	setup();
+
+	cleanup();
+
+}
+
+/*
+ * setup() - performs all ONE TIME setup for this test.
+ */
+void setup(void)
+{
+
+	tst_sig(NOFORK, DEF_HANDLER, cleanup);
+
+	TEST_PAUSE;
+
+	/* Create a temporary directory and make it current. */
+	tst_tmpdir();
+
+	SAFE_TOUCH(cleanup, fname, 0700, NULL);
+	SAFE_TOUCH(cleanup, mname, 0700, NULL);
+
+	/* create "old" directory */
+	SAFE_MKDIR(cleanup, fdir, 00770);
+
+	/* create another directory */
+	SAFE_MKDIR(cleanup, mdir, 00770);
+}
+
+/*
+ * cleanup() - performs all ONE TIME cleanup for this test at
+ *             completion or premature exit.
+ */
+void cleanup(void)
+{
+
+	/*
+	 * Remove the temporary directory.
+	 */
+	tst_rmdir();
+}

--- a/ltp_src/testcases/kernel/syscalls/rename/rename08_run.c
+++ b/ltp_src/testcases/kernel/syscalls/rename/rename08_run.c
@@ -1,0 +1,169 @@
+/*
+ *
+ *   Copyright (c) International Business Machines  Corp., 2001
+ *
+ *   This program is free software;  you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *   the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program;  if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * NAME
+ *	rename08
+ *
+ * DESCRIPTION
+ *	This test will verify that rename(2) syscall failed in EFAULT
+ *
+ * ALGORITHM
+ *	Setup:
+ *		Setup signal handling.
+ *		Create temporary directory.
+ *		Pause for SIGUSR1 if option specified.
+ *		Create a valid file to use in the rename() call.
+ *
+ *	Test:
+ *		Loop if the proper options are given.
+ *              1.  "old" is a valid file, newpath points to address
+ *                   outside allocated address space
+ *                  rename the "old" to the "new" file
+ *                  verify rename() failed with error EFAULT
+ *
+ *              2.  "old" points to address outside allocated address space
+ *                  ,"new" is a valid file
+ *                  rename the "old" to the "new"
+ *                  verify rename() failed with error EFAULT
+ *
+ *              3.  oldpath and newpath are all NULL
+ *                  try to rename NULL to NULL
+ *                  verify rename() failed with error EFAULT
+ *	Cleanup:
+ *		Print errno log and/or timing stats if options given
+ *		Delete the temporary directory created.*
+ * USAGE
+ *	rename08 [-c n] [-e] [-i n] [-I x] [-P x] [-t]
+ *	where,  -c n : Run n copies concurrently.
+ *		-e   : Turn on errno logging.
+ *		-i n : Execute test n times.
+ *		-I x : Execute test for x seconds.
+ *		-P x : Pause for x seconds between iterations.
+ *		-t   : Turn on syscall timing.
+ *
+ * HISTORY
+ *	07/2001 Ported by Wayne Boyer
+ *
+ * RESTRICTIONS
+ *	None.
+ */
+#include <sys/types.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include "test.h"
+
+void setup();
+void cleanup();
+
+char *TCID = "rename08";
+
+char *bad_addr = 0;
+
+int fd;
+char fname[255] = "/tmp/rename08_fname";
+
+struct test_case_t {
+	char *fd;
+	char *fd2;
+	int error;
+} TC[] = {
+#if !defined(UCLINUX)
+	/* "new" file is invalid - EFAULT */
+	{fname, (char *)-1, EFAULT},
+	/* "old" file is invalid - EFAULT */
+	{(char *)-1, fname, EFAULT},
+#endif
+	/* both files are NULL - EFAULT */
+	{NULL, NULL, EFAULT}
+};
+
+int TST_TOTAL = ARRAY_SIZE(TC);
+
+int main(int ac, char **av)
+{
+	int lc;
+	int i;
+
+	/*
+	 * parse standard options
+	 */
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	setup();
+
+	/*
+	 * check looping state if -i option given
+	 */
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+
+		tst_count = 0;
+
+		/* loop through the test cases */
+		for (i = 0; i < TST_TOTAL; i++) {
+
+			TEST(rename(TC[i].fd, TC[i].fd2));
+
+			if (TEST_RETURN != -1) {
+				tst_resm(TFAIL, "call succeeded unexpectedly");
+				continue;
+			}
+
+			if (TEST_ERRNO == TC[i].error) {
+				tst_resm(TPASS, "expected failure - "
+					 "errno = %d : %s", TEST_ERRNO,
+					 strerror(TEST_ERRNO));
+			} else {
+				tst_resm(TFAIL, "unexpected error - %d : %s - "
+					 "expected %d", TEST_ERRNO,
+					 strerror(TEST_ERRNO), TC[i].error);
+			}
+		}
+	}
+
+	cleanup();
+	tst_exit();
+
+}
+
+/*
+ * setup() - performs all ONE TIME setup for this test.
+ */
+void setup(void)
+{
+#if !defined(UCLINUX)
+	bad_addr = mmap(0, 1, PROT_NONE,
+			MAP_PRIVATE_EXCEPT_UCLINUX | MAP_ANONYMOUS, 0, 0);
+	if (bad_addr == MAP_FAILED) {
+		tst_brkm(TBROK, cleanup, "mmap failed");
+	}
+	TC[0].fd2 = bad_addr;
+	TC[1].fd = bad_addr;
+#endif
+}
+
+/*
+ * cleanup() - performs all ONE TIME cleanup for this test at
+ *              completion or premature exit.
+ */
+void cleanup(void)
+{}

--- a/ltp_src/testcases/kernel/syscalls/rename/rename08_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/rename/rename08_setup.c
@@ -1,0 +1,138 @@
+/*
+ *
+ *   Copyright (c) International Business Machines  Corp., 2001
+ *
+ *   This program is free software;  you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *   the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program;  if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * NAME
+ *	rename08
+ *
+ * DESCRIPTION
+ *	This test will verify that rename(2) syscall failed in EFAULT
+ *
+ * ALGORITHM
+ *	Setup:
+ *		Setup signal handling.
+ *		Create temporary directory.
+ *		Pause for SIGUSR1 if option specified.
+ *		Create a valid file to use in the rename() call.
+ *
+ *	Test:
+ *		Loop if the proper options are given.
+ *              1.  "old" is a valid file, newpath points to address
+ *                   outside allocated address space
+ *                  rename the "old" to the "new" file
+ *                  verify rename() failed with error EFAULT
+ *
+ *              2.  "old" points to address outside allocated address space
+ *                  ,"new" is a valid file
+ *                  rename the "old" to the "new"
+ *                  verify rename() failed with error EFAULT
+ *
+ *              3.  oldpath and newpath are all NULL
+ *                  try to rename NULL to NULL
+ *                  verify rename() failed with error EFAULT
+ *	Cleanup:
+ *		Print errno log and/or timing stats if options given
+ *		Delete the temporary directory created.*
+ * USAGE
+ *	rename08 [-c n] [-e] [-i n] [-I x] [-P x] [-t]
+ *	where,  -c n : Run n copies concurrently.
+ *		-e   : Turn on errno logging.
+ *		-i n : Execute test n times.
+ *		-I x : Execute test for x seconds.
+ *		-P x : Pause for x seconds between iterations.
+ *		-t   : Turn on syscall timing.
+ *
+ * HISTORY
+ *	07/2001 Ported by Wayne Boyer
+ *
+ * RESTRICTIONS
+ *	None.
+ */
+#include <sys/types.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include "test.h"
+
+void setup();
+void cleanup();
+
+char *TCID = "rename08";
+
+char *bad_addr = 0;
+
+int fd;
+char fname[255] = "/tmp/rename08_fname";
+
+struct test_case_t {
+	char *fd;
+	char *fd2;
+	int error;
+} TC[] = {
+#if !defined(UCLINUX)
+	/* "new" file is invalid - EFAULT */
+	{fname, (char *)-1, EFAULT},
+	/* "old" file is invalid - EFAULT */
+	{(char *)-1, fname, EFAULT},
+#endif
+	/* both files are NULL - EFAULT */
+	{NULL, NULL, EFAULT}
+};
+
+int TST_TOTAL = ARRAY_SIZE(TC);
+
+int main(int ac, char **av)
+{
+	/*
+	 * parse standard options
+	 */
+	tst_parse_opts(ac, av, NULL, NULL);
+	setup();
+	tst_resm(TPASS, "No test function defined here");
+	cleanup();
+	tst_exit();
+}
+
+/*
+ * setup() - performs all ONE TIME setup for this test.
+ */
+void setup(void)
+{
+	tst_sig(NOFORK, DEF_HANDLER, cleanup);
+	TEST_PAUSE;
+
+	/* Create a temporary directory and make it current. */
+	tst_tmpdir();
+	SAFE_TOUCH(cleanup, fname, 0700, NULL);
+}
+
+/*
+ * cleanup() - performs all ONE TIME cleanup for this test at
+ *              completion or premature exit.
+ */
+void cleanup(void)
+{
+
+	/*
+	 * Remove the temporary directory.
+	 */
+	tst_rmdir();
+}

--- a/ltp_src/testcases/kernel/syscalls/rename/rename10_run.c
+++ b/ltp_src/testcases/kernel/syscalls/rename/rename10_run.c
@@ -1,0 +1,154 @@
+/*
+ *
+ *   Copyright (c) International Business Machines  Corp., 2001
+ *
+ *   This program is free software;  you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *   the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program;  if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * NAME
+ *	rename10
+ *
+ * DESCRIPTION
+ *	This test will verify that rename(2) syscall fails with ENAMETOOLONG
+ *      and ENOENT
+ *
+ * ALGORITHM
+ *	Setup:
+ *		Setup signal handling.
+ *		Create temporary directory.
+ *		Pause for SIGUSR1 if option specified.
+ *              create the "old" file
+ *
+ *	Test:
+ *		Loop if the proper options are given.
+ *              1.  rename the "old" to the "new" file
+ *                  verify rename() failed with error ENAMETOOLONG
+ *
+ *              2.  "new" path contains a directory that does not exist
+ *                  rename the "old" to the "new"
+ *                  verify rename() failed with error ENOENT
+ *	Cleanup:
+ *		Print errno log and/or timing stats if options given
+ *		Delete the temporary directory created.*
+ *
+ * USAGE
+ *	rename10 [-c n] [-e] [-i n] [-I x] [-P x] [-t]
+ *	where,  -c n : Run n copies concurrently.
+ *		-e   : Turn on errno logging.
+ *		-i n : Execute test n times.
+ *		-I x : Execute test for x seconds.
+ *		-P x : Pause for x seconds between iterations.
+ *		-t   : Turn on syscall timing.
+ *
+ * HISTORY
+ *	07/2001 Ported by Wayne Boyer
+ *
+ * RESTRICTIONS
+ *	None.
+ */
+#include <sys/types.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include "test.h"
+
+void setup();
+void cleanup();
+
+char *TCID = "rename10";
+int TST_TOTAL = 2;
+
+char badmname[] =
+    "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyz";
+
+int fd;
+char fname[255] = "/tmp/rename10_fname";
+char mdir[255]= "/tmp/rename10_mdir";
+char mname[255] = "/tmp/rename10_mdir/rename10_mname";
+
+struct test_case_t {
+	char *fd1;
+	char *fd2;
+	int error;
+} TC[] = {
+	/* badmname is too long for a file name - ENAMETOOLONG */
+	{fname, badmname, ENAMETOOLONG},
+	    /* mname contains a directory component which does not exist - ENOENT */
+	{fname, mname, ENOENT}
+};
+
+int main(int ac, char **av)
+{
+	int lc;
+	int i;
+
+	/*
+	 * parse standard options
+	 */
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	/*
+	 * perform global setup for test
+	 */
+	setup();
+
+	/*
+	 * check looping state if -i option given
+	 */
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+
+		tst_count = 0;
+
+		/* loop through the test cases */
+		for (i = 0; i < TST_TOTAL; i++) {
+
+			TEST(rename(TC[i].fd1, TC[i].fd2));
+
+			if (TEST_RETURN != -1) {
+				tst_resm(TFAIL, "call succeeded unexpectedly");
+				continue;
+			}
+
+			if (TEST_ERRNO == TC[i].error) {
+				tst_resm(TPASS, "expected failure - "
+					 "errno = %d : %s", TEST_ERRNO,
+					 strerror(TEST_ERRNO));
+			} else {
+				tst_resm(TFAIL, "unexpected error - %d : %s - "
+					 "expected %d", TEST_ERRNO,
+					 strerror(TEST_ERRNO), TC[i].error);
+			}
+		}
+	}
+
+	cleanup();
+	tst_exit();
+
+}
+
+/*
+ * setup() - performs all ONE TIME setup for this test.
+ */
+void setup(void)
+{}
+
+/*
+ * cleanup() - performs all ONE TIME cleanup for this test at
+ *             completion or premature exit.
+ */
+void cleanup(void)
+{}

--- a/ltp_src/testcases/kernel/syscalls/rename/rename10_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/rename/rename10_setup.c
@@ -1,0 +1,141 @@
+/*
+ *
+ *   Copyright (c) International Business Machines  Corp., 2001
+ *
+ *   This program is free software;  you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *   the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program;  if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * NAME
+ *	rename10
+ *
+ * DESCRIPTION
+ *	This test will verify that rename(2) syscall fails with ENAMETOOLONG
+ *      and ENOENT
+ *
+ * ALGORITHM
+ *	Setup:
+ *		Setup signal handling.
+ *		Create temporary directory.
+ *		Pause for SIGUSR1 if option specified.
+ *              create the "old" file
+ *
+ *	Test:
+ *		Loop if the proper options are given.
+ *              1.  rename the "old" to the "new" file
+ *                  verify rename() failed with error ENAMETOOLONG
+ *
+ *              2.  "new" path contains a directory that does not exist
+ *                  rename the "old" to the "new"
+ *                  verify rename() failed with error ENOENT
+ *	Cleanup:
+ *		Print errno log and/or timing stats if options given
+ *		Delete the temporary directory created.*
+ *
+ * USAGE
+ *	rename10 [-c n] [-e] [-i n] [-I x] [-P x] [-t]
+ *	where,  -c n : Run n copies concurrently.
+ *		-e   : Turn on errno logging.
+ *		-i n : Execute test n times.
+ *		-I x : Execute test for x seconds.
+ *		-P x : Pause for x seconds between iterations.
+ *		-t   : Turn on syscall timing.
+ *
+ * HISTORY
+ *	07/2001 Ported by Wayne Boyer
+ *
+ * RESTRICTIONS
+ *	None.
+ */
+#include <sys/types.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include "test.h"
+
+void setup();
+void cleanup();
+
+char *TCID = "rename10";
+int TST_TOTAL = 2;
+
+char badmname[] =
+    "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyzabcdefghijklmnopqrstmnopqrstuvwxyz";
+
+int fd;
+char fname[255] = "/tmp/rename10_fname";
+char mdir[255]= "/tmp/rename10_mdir";
+char mname[255] = "/tmp/rename10_mdir/rename10_mname";
+
+struct test_case_t {
+	char *fd1;
+	char *fd2;
+	int error;
+} TC[] = {
+	/* badmname is too long for a file name - ENAMETOOLONG */
+	{fname, badmname, ENAMETOOLONG},
+	    /* mname contains a directory component which does not exist - ENOENT */
+	{fname, mname, ENOENT}
+};
+
+int main(int ac, char **av)
+{
+	int lc;
+	int i;
+
+	/*
+	 * parse standard options
+	 */
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	/*
+	 * perform global setup for test
+	 */
+	setup();
+	tst_resm(TPASS, "No test function defined here");
+	cleanup();
+	tst_exit();
+
+}
+
+/*
+ * setup() - performs all ONE TIME setup for this test.
+ */
+void setup(void)
+{
+
+	tst_sig(NOFORK, DEF_HANDLER, cleanup);
+
+	TEST_PAUSE;
+
+	/* Create a temporary directory and make it current. */
+	tst_tmpdir();
+
+	SAFE_TOUCH(cleanup, fname, 0700, NULL);
+}
+
+/*
+ * cleanup() - performs all ONE TIME cleanup for this test at
+ *             completion or premature exit.
+ */
+void cleanup(void)
+{
+
+	/*
+	 * Remove the temporary directory.
+	 */
+	tst_rmdir();
+}

--- a/ltp_src/testcases/kernel/syscalls/rename/rename13_run.c
+++ b/ltp_src/testcases/kernel/syscalls/rename/rename13_run.c
@@ -1,0 +1,164 @@
+/*
+ *
+ *   Copyright (c) International Business Machines  Corp., 2001
+ *
+ *   This program is free software;  you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *   the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program;  if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * NAME
+ *	rename13
+ *
+ * DESCRIPTION
+ *	Verify rename() return successfully and performs no other action
+ *      when "old" file and "new" file link to the same file.
+ *
+ * ALGORITHM
+ *	Setup:
+ *		Setup signal handling.
+ *		Create temporary directory.
+ *		Pause for SIGUSR1 if option specified.
+ *
+ *	Test:
+ *		Loop if the proper options are given.
+ *                  create the "old" file
+ *                  link the "new" file to the "old" file
+ *                  rename the "old" to the "new" file
+ *                  verify the "new" file points to the original file
+ *                  verify the "old" file exists and points to
+ *                         the original file
+ *	Cleanup:
+ *		Print errno log and/or timing stats if options given
+ *		Delete the temporary directory created.
+ *
+ * USAGE
+ *	rename13 [-c n] [-f] [-i n] [-I x] [-P x] [-t]
+ *	where,  -c n : Run n copies concurrently.
+ *		-f   : Turn off functionality Testing.
+ *		-i n : Execute test n times.
+ *		-I x : Execute test for x seconds.
+ *		-P x : Pause for x seconds between iterations.
+ *		-t   : Turn on syscall timing.
+ *
+ * HISTORY
+ *	07/2001 Ported by Wayne Boyer
+ *
+ * RESTRICTIONS
+ *	None.
+ */
+#include <sys/types.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include "test.h"
+#include "safe_macros.h"
+
+void setup();
+void cleanup();
+
+char *TCID = "rename13";
+int TST_TOTAL = 1;
+
+int fd;
+char fname[255] = "/tmp/rename13_fname";
+char mname[255] = "/tmp/rename13_mname";
+struct stat buf1, buf2;
+dev_t olddev;
+ino_t oldino;
+
+int main(int ac, char **av)
+{
+	int lc;
+
+	/*
+	 * parse standard options
+	 */
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	/*
+	 * perform global setup for test
+	 */
+	setup();
+
+	/*
+	 * check looping state if -i option given
+	 */
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+
+		tst_count = 0;
+
+		/*
+		 * TEST rename()works when
+		 * both old file and new file link to the same file
+		 */
+
+		/* Call rename(2) */
+		TEST(rename(fname, mname));
+
+		if (TEST_RETURN == -1) {
+			tst_resm(TFAIL, "rename(%s, %s) failed", fname, mname);
+			continue;
+		}
+
+		/* check the existence of "new", and get the status */
+		SAFE_STAT(cleanup, mname, &buf2);
+
+		/* check the existence of "old", and get the status */
+		SAFE_STAT(cleanup, fname, &buf1);
+
+		/* verify the new file is the same as the original */
+		if (buf2.st_dev != olddev || buf2.st_ino != oldino) {
+			tst_resm(TFAIL,
+				 "rename() failed: new file does "
+				 "not point to the same file as old "
+				 "file");
+			continue;
+		}
+
+		/* verify the old file is unchanged */
+		if (buf1.st_dev != olddev || buf1.st_ino != oldino) {
+			tst_resm(TFAIL,
+				 "rename() failed: old file does "
+				 "not point to the original file");
+			continue;
+		}
+
+		tst_resm(TPASS, "functionality of rename() is correct");
+	}
+
+	cleanup();
+	tst_exit();
+}
+
+/*
+ * setup() - performs all ONE TIME setup for this test.
+ */
+void setup(void)
+{
+	SAFE_STAT(cleanup, fname, &buf1);
+
+	/* save the dev and inode */
+	olddev = buf1.st_dev;
+	oldino = buf1.st_ino;
+}
+
+/*
+ * cleanup() - performs all ONE TIME cleanup for this test at
+ *             completion or premature exit.
+ */
+void cleanup(void)
+{}

--- a/ltp_src/testcases/kernel/syscalls/rename/rename13_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/rename/rename13_setup.c
@@ -1,0 +1,130 @@
+/*
+ *
+ *   Copyright (c) International Business Machines  Corp., 2001
+ *
+ *   This program is free software;  you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *   the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program;  if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * NAME
+ *	rename13
+ *
+ * DESCRIPTION
+ *	Verify rename() return successfully and performs no other action
+ *      when "old" file and "new" file link to the same file.
+ *
+ * ALGORITHM
+ *	Setup:
+ *		Setup signal handling.
+ *		Create temporary directory.
+ *		Pause for SIGUSR1 if option specified.
+ *
+ *	Test:
+ *		Loop if the proper options are given.
+ *                  create the "old" file
+ *                  link the "new" file to the "old" file
+ *                  rename the "old" to the "new" file
+ *                  verify the "new" file points to the original file
+ *                  verify the "old" file exists and points to
+ *                         the original file
+ *	Cleanup:
+ *		Print errno log and/or timing stats if options given
+ *		Delete the temporary directory created.
+ *
+ * USAGE
+ *	rename13 [-c n] [-f] [-i n] [-I x] [-P x] [-t]
+ *	where,  -c n : Run n copies concurrently.
+ *		-f   : Turn off functionality Testing.
+ *		-i n : Execute test n times.
+ *		-I x : Execute test for x seconds.
+ *		-P x : Pause for x seconds between iterations.
+ *		-t   : Turn on syscall timing.
+ *
+ * HISTORY
+ *	07/2001 Ported by Wayne Boyer
+ *
+ * RESTRICTIONS
+ *	None.
+ */
+#include <sys/types.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include "test.h"
+#include "safe_macros.h"
+
+void setup();
+void cleanup();
+
+char *TCID = "rename13";
+int TST_TOTAL = 1;
+
+int fd;
+char fname[255] = "/tmp/rename13_fname";
+char mname[255] = "/tmp/rename13_mname";
+struct stat buf1, buf2;
+dev_t olddev;
+ino_t oldino;
+
+int main(int ac, char **av)
+{
+	int lc;
+
+	/*
+	 * parse standard options
+	 */
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	/*
+	 * perform global setup for test
+	 */
+	setup();
+	cleanup();
+	// tst_exit();
+}
+
+/*
+ * setup() - performs all ONE TIME setup for this test.
+ */
+void setup(void)
+{
+
+	tst_sig(NOFORK, DEF_HANDLER, cleanup);
+
+	TEST_PAUSE;
+
+	/* Create a temporary directory and make it current. */
+	tst_tmpdir();
+	SAFE_TOUCH(cleanup, fname, 0700, NULL);
+
+	/* link the "new" file to the "old" file */
+	SAFE_LINK(cleanup, fname, mname);
+}
+
+/*
+ * cleanup() - performs all ONE TIME cleanup for this test at
+ *             completion or premature exit.
+ */
+void cleanup(void)
+{
+
+	/*
+	 * Remove the temporary directory.
+	 */
+	tst_rmdir();
+
+}

--- a/ltp_src/testcases/kernel/syscalls/statfs/statfs02_run.c
+++ b/ltp_src/testcases/kernel/syscalls/statfs/statfs02_run.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) International Business Machines  Corp., 2001
+ *	07/2001 Ported by Wayne Boyer
+ *
+ * This program is free software;  you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program;  if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * DESCRIPTION
+ *	1.	Use a component of the pathname, which is not a directory
+ *		in the "path" parameter to statfs(). Expect ENOTDIR
+ *	2.	Pass a filename which doesn't exist, and expect ENOENT.
+ *	3.	Pass a pathname which is more than MAXNAMLEN, and expect
+ *		ENAMETOOLONG.
+ *	4.	Pass a pointer to the pathname outside the address space of
+ *		the process, and expect EFAULT.
+ *	5.	Pass a pointer to the buf paramter outside the address space
+ *		of the process, and expect EFAULT.
+ *	6.	Pass a filename which has too many symbolic links, and expect
+ *		ELOOP.
+ */
+
+#include <sys/types.h>
+#include <sys/statfs.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/vfs.h>
+#include <sys/mman.h>
+#include <errno.h>
+#include "test.h"
+#include "safe_macros.h"
+
+char *TCID = "statfs02";
+
+static int fd;
+
+#define TEST_FILE		"/tmp/statfs_file"
+#define TEST_FILE1		TEST_FILE"/statfs_file1"
+#define TEST_NOEXIST		"/tmp/statfs_noexist"
+#define TEST_SYMLINK		"/tmp/statfs_symlink"
+
+static char test_toolong[PATH_MAX+2];
+static struct statfs buf;
+
+static struct test_case_t {
+	char *path;
+	struct statfs *buf;
+	int exp_error;
+} TC[] = {
+	{TEST_FILE1, &buf, ENOTDIR},
+	{TEST_NOEXIST, &buf, ENOENT},
+	{test_toolong, &buf, ENAMETOOLONG},
+#ifndef UCLINUX
+	{(char *)-1, &buf, EFAULT},
+	{TEST_FILE, (struct statfs *)-1, EFAULT},
+#endif
+	{TEST_SYMLINK, &buf, ELOOP},
+};
+
+int TST_TOTAL = ARRAY_SIZE(TC);
+static void setup(void);
+static void cleanup(void);
+static void statfs_verify(const struct test_case_t *);
+
+int main(int ac, char **av)
+{
+	int lc;
+	int i;
+
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	setup();
+
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+		tst_count = 0;
+		for (i = 0; i < TST_TOTAL; i++)
+			statfs_verify(&TC[i]);
+	}
+
+	cleanup();
+	tst_exit();
+}
+
+static void setup(void)
+{
+	memset(test_toolong, 'a', PATH_MAX+1);
+
+#if !defined(UCLINUX)
+	TC[3].path = SAFE_MMAP(cleanup, 0, 1, PROT_NONE,
+			       MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
+#endif
+
+}
+
+static void statfs_verify(const struct test_case_t *test)
+{
+	TEST(statfs(test->path, test->buf));
+
+	if (TEST_RETURN != -1) {
+		tst_resm(TFAIL, "call succeeded unexpectedly");
+		return;
+	}
+
+	if (TEST_ERRNO == test->exp_error) {
+		tst_resm(TPASS | TTERRNO, "expected failure");
+	} else {
+		tst_resm(TFAIL | TTERRNO, "unexpected error, expected %d",
+			 TEST_ERRNO);
+	}
+}
+
+static void cleanup(void)
+{
+	if (fd > 0)
+		close(fd);
+}

--- a/ltp_src/testcases/kernel/syscalls/statfs/statfs02_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/statfs/statfs02_setup.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) International Business Machines  Corp., 2001
+ *	07/2001 Ported by Wayne Boyer
+ *
+ * This program is free software;  you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program;  if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * DESCRIPTION
+ *	1.	Use a component of the pathname, which is not a directory
+ *		in the "path" parameter to statfs(). Expect ENOTDIR
+ *	2.	Pass a filename which doesn't exist, and expect ENOENT.
+ *	3.	Pass a pathname which is more than MAXNAMLEN, and expect
+ *		ENAMETOOLONG.
+ *	4.	Pass a pointer to the pathname outside the address space of
+ *		the process, and expect EFAULT.
+ *	5.	Pass a pointer to the buf paramter outside the address space
+ *		of the process, and expect EFAULT.
+ *	6.	Pass a filename which has too many symbolic links, and expect
+ *		ELOOP.
+ */
+
+#include <sys/types.h>
+#include <sys/statfs.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/vfs.h>
+#include <sys/mman.h>
+#include <errno.h>
+#include "test.h"
+#include "safe_macros.h"
+
+char *TCID = "statfs02";
+
+static int fd;
+
+#define TEST_FILE		"/tmp/statfs_file"
+#define TEST_FILE1		TEST_FILE"/statfs_file1"
+#define TEST_NOEXIST		"/tmp/statfs_noexist"
+#define TEST_SYMLINK		"/tmp/statfs_symlink"
+
+static char test_toolong[PATH_MAX+2];
+static struct statfs buf;
+
+static struct test_case_t {
+	char *path;
+	struct statfs *buf;
+	int exp_error;
+} TC[] = {
+	{TEST_FILE1, &buf, ENOTDIR},
+	{TEST_NOEXIST, &buf, ENOENT},
+	{test_toolong, &buf, ENAMETOOLONG},
+#ifndef UCLINUX
+	{(char *)-1, &buf, EFAULT},
+	{TEST_FILE, (struct statfs *)-1, EFAULT},
+#endif
+	{TEST_SYMLINK, &buf, ELOOP},
+};
+
+int TST_TOTAL = ARRAY_SIZE(TC);
+static void setup(void);
+static void cleanup(void);
+static void statfs_verify(const struct test_case_t *);
+
+int main(int ac, char **av)
+{
+	int lc;
+	int i;
+
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	setup();
+
+	// for (lc = 0; TEST_LOOPING(lc); lc++) {
+	// 	tst_count = 0;
+	// 	for (i = 0; i < TST_TOTAL; i++)
+	// 		statfs_verify(&TC[i]);
+	// }
+
+	// cleanup();
+	// tst_exit();
+}
+
+static void setup(void)
+{
+	tst_sig(NOFORK, DEF_HANDLER, cleanup);
+
+	TEST_PAUSE;
+
+	tst_tmpdir();
+
+	fd = SAFE_CREAT(cleanup, TEST_FILE, 0444);
+
+	memset(test_toolong, 'a', PATH_MAX+1);
+
+#if !defined(UCLINUX)
+	TC[3].path = SAFE_MMAP(cleanup, 0, 1, PROT_NONE,
+			       MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
+#endif
+
+	SAFE_SYMLINK(cleanup, TEST_SYMLINK, "/tmp/statfs_symlink_2");
+	SAFE_SYMLINK(cleanup, "/tmp/statfs_symlink_2", TEST_SYMLINK);
+}
+
+static void statfs_verify(const struct test_case_t *test)
+{
+	// TEST(statfs(test->path, test->buf));
+
+	// if (TEST_RETURN != -1) {
+	// 	tst_resm(TFAIL, "call succeeded unexpectedly");
+	// 	return;
+	// }
+
+	// if (TEST_ERRNO == test->exp_error) {
+	// 	tst_resm(TPASS | TTERRNO, "expected failure");
+	// } else {
+	// 	tst_resm(TFAIL | TTERRNO, "unexpected error, expected %d",
+	// 		 TEST_ERRNO);
+	// }
+}
+
+static void cleanup(void)
+{
+	if (fd > 0)
+		close(fd);
+
+	tst_rmdir();
+}

--- a/ltp_src/testcases/kernel/syscalls/statvfs/statvfs02_run.c
+++ b/ltp_src/testcases/kernel/syscalls/statvfs/statvfs02_run.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2014 Fujitsu Ltd.
+ * Author: Zeng Linggang <zenglg.jy@cn.fujitsu.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+/*
+ * Test Description:
+ *  Verify that,
+ *   1. path is NULL, EFAULT would return.
+ *   2. Too many symbolic links were encountered in translating path,
+ *	ELOOP would return.
+ *   3. path is too long, ENAMETOOLONG would return.
+ *   4. The file referred to by path does not exist, ENOENT would return.
+ *   5. A component of the path prefix of path is not a directory,
+ *	ENOENT would return.
+ */
+
+#include <errno.h>
+#include <sys/statvfs.h>
+#include <sys/mman.h>
+
+#include "test.h"
+#include "safe_macros.h"
+
+#define TEST_SYMLINK	"/tmp/statvfs_symlink"
+#define TEST_FILE	"/tmp/statvfs_file"
+
+char *TCID = "statvfs02";
+
+static struct statvfs buf;
+static char nametoolong[PATH_MAX+2];
+static void setup(void);
+static void cleanup(void);
+
+static struct test_case_t {
+	char *path;
+	struct statvfs *buf;
+	int exp_errno;
+} test_cases[] = {
+	{NULL, &buf, EFAULT},
+	{TEST_SYMLINK, &buf, ELOOP},
+	{nametoolong, &buf, ENAMETOOLONG},
+	{"filenoexist", &buf, ENOENT},
+	{"/tmp/statvfs_file/test", &buf, ENOTDIR},
+};
+
+int TST_TOTAL = ARRAY_SIZE(test_cases);
+static void statvfs_verify(const struct test_case_t *);
+
+int main(int argc, char **argv)
+{
+	int i, lc;
+
+	tst_parse_opts(argc, argv, NULL, NULL);
+
+	setup();
+
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+		tst_count = 0;
+		for (i = 0; i < TST_TOTAL; i++)
+			statvfs_verify(&test_cases[i]);
+	}
+
+	cleanup();
+	tst_exit();
+}
+
+static void setup(void)
+{
+	// tst_sig(NOFORK, DEF_HANDLER, cleanup);
+
+	// TEST_PAUSE;
+
+	// tst_tmpdir();
+
+	// SAFE_SYMLINK(cleanup, TEST_SYMLINK, "/tmp/statfs_symlink_2");
+	// SAFE_SYMLINK(cleanup, "/tmp/statfs_symlink_2", TEST_SYMLINK);
+
+	memset(nametoolong, 'a', PATH_MAX+1);
+
+	// SAFE_TOUCH(cleanup, TEST_FILE, 0644, NULL);
+
+	test_cases[0].path = SAFE_MMAP(cleanup, NULL, 1, PROT_NONE,
+	                               MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
+}
+
+static void statvfs_verify(const struct test_case_t *test)
+{
+	TEST(statvfs(test->path, test->buf));
+
+	if (TEST_RETURN != -1) {
+		tst_resm(TFAIL, "statvfs() succeeded unexpectedly");
+		return;
+	}
+
+	if (TEST_ERRNO == test->exp_errno) {
+		tst_resm(TPASS | TTERRNO, "statvfs() failed as expected");
+	} else {
+		tst_resm(TFAIL | TTERRNO,
+			 "statvfs() failed unexpectedly; expected: %d - %s",
+			 test->exp_errno, strerror(test->exp_errno));
+	}
+}
+
+static void cleanup(void)
+{}

--- a/ltp_src/testcases/kernel/syscalls/statvfs/statvfs02_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/statvfs/statvfs02_setup.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2014 Fujitsu Ltd.
+ * Author: Zeng Linggang <zenglg.jy@cn.fujitsu.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+/*
+ * Test Description:
+ *  Verify that,
+ *   1. path is NULL, EFAULT would return.
+ *   2. Too many symbolic links were encountered in translating path,
+ *	ELOOP would return.
+ *   3. path is too long, ENAMETOOLONG would return.
+ *   4. The file referred to by path does not exist, ENOENT would return.
+ *   5. A component of the path prefix of path is not a directory,
+ *	ENOENT would return.
+ */
+
+#include <errno.h>
+#include <sys/statvfs.h>
+#include <sys/mman.h>
+
+#include "test.h"
+#include "safe_macros.h"
+
+#define TEST_SYMLINK	"/tmp/statvfs_symlink"
+#define TEST_FILE	"/tmp/statvfs_file"
+
+char *TCID = "statvfs02";
+
+static struct statvfs buf;
+static char nametoolong[PATH_MAX+2];
+static void setup(void);
+static void cleanup(void);
+
+static struct test_case_t {
+	char *path;
+	struct statvfs *buf;
+	int exp_errno;
+} test_cases[] = {
+	{NULL, &buf, EFAULT},
+	{TEST_SYMLINK, &buf, ELOOP},
+	{nametoolong, &buf, ENAMETOOLONG},
+	{"filenoexist", &buf, ENOENT},
+	{"statvfs_file/test", &buf, ENOTDIR},
+};
+
+int TST_TOTAL = ARRAY_SIZE(test_cases);
+static void statvfs_verify(const struct test_case_t *);
+
+int main(int argc, char **argv)
+{
+	int i, lc;
+
+	tst_parse_opts(argc, argv, NULL, NULL);
+
+	setup();
+
+	// for (lc = 0; TEST_LOOPING(lc); lc++) {
+	// 	tst_count = 0;
+	// 	for (i = 0; i < TST_TOTAL; i++)
+	// 		statvfs_verify(&test_cases[i]);
+	// }
+
+	// cleanup();
+	// tst_exit();
+}
+
+static void setup(void)
+{
+	tst_sig(NOFORK, DEF_HANDLER, cleanup);
+
+	TEST_PAUSE;
+
+	tst_tmpdir();
+
+	SAFE_SYMLINK(cleanup, TEST_SYMLINK, "/tmp/statfs_symlink_2");
+	SAFE_SYMLINK(cleanup, "/tmp/statfs_symlink_2", TEST_SYMLINK);
+
+	memset(nametoolong, 'a', PATH_MAX+1);
+
+	SAFE_TOUCH(cleanup, TEST_FILE, 0644, NULL);
+
+	test_cases[0].path = SAFE_MMAP(cleanup, NULL, 1, PROT_NONE,
+	                               MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
+}
+
+static void statvfs_verify(const struct test_case_t *test)
+{
+	// TEST(statvfs(test->path, test->buf));
+
+	// if (TEST_RETURN != -1) {
+	// 	tst_resm(TFAIL, "statvfs() succeeded unexpectedly");
+	// 	return;
+	// }
+
+	// if (TEST_ERRNO == test->exp_errno) {
+	// 	tst_resm(TPASS | TTERRNO, "statvfs() failed as expected");
+	// } else {
+	// 	tst_resm(TFAIL | TTERRNO,
+	// 		 "statvfs() failed unexpectedly; expected: %d - %s",
+	// 		 test->exp_errno, strerror(test->exp_errno));
+	// }
+}
+
+static void cleanup(void)
+{
+	tst_rmdir();
+}

--- a/ltp_src/testcases/kernel/syscalls/unlink/unlink05_run.c
+++ b/ltp_src/testcases/kernel/syscalls/unlink/unlink05_run.c
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) 2000 Silicon Graphics, Inc.  All Rights Reserved.
+ */
+
+/*
+ * Description:
+ * The testcase checks the basic functionality of the unlink(2).
+ * 1) unlink() can delete regular file successfully.
+ * 2) unlink() can delete fifo file successfully.
+ */
+
+#include <errno.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <stdio.h>
+#include "tst_test.h"
+
+static void file_create(char *);
+static void fifo_create(char *);
+
+#define C_FILE "/tmp/unlink05_file"
+#define C_FIFO "/tmp/unlink05_fifo"
+
+static struct test_case_t {
+	void (*setupfunc)(char *);
+	char *desc;
+} tcases[] = {
+	{file_create, C_FILE},
+	{fifo_create, C_FIFO},
+};
+
+static void file_create(char *name)
+{
+	SAFE_TOUCH(name, 0777, NULL);
+}
+
+static void fifo_create(char *name)
+{
+	SAFE_MKFIFO(name, 0777);
+}
+
+static void verify_unlink(unsigned int n)
+{
+	struct test_case_t *tc = &tcases[n];
+
+	TEST(unlink(tc->desc));
+	if (TST_RET == -1) {
+		tst_res(TFAIL | TTERRNO, "unlink(%s) failed", tc->desc);
+		return;
+	}
+
+	if (!access(tc->desc, F_OK)) {
+		tst_res(TFAIL, "unlink(%s) succeeded, but %s still existed",
+			tc->desc, tc->desc);
+		return;
+	}
+
+	tst_res(TPASS, "unlink(%s) succeeded", tc->desc);
+}
+
+static struct tst_test test = {
+	.needs_tmpdir = 1,
+	.tcnt = ARRAY_SIZE(tcases),
+	.test = verify_unlink,
+};

--- a/ltp_src/testcases/kernel/syscalls/unlink/unlink05_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/unlink/unlink05_setup.c
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) 2000 Silicon Graphics, Inc.  All Rights Reserved.
+ */
+
+/*
+ * Description:
+ * The testcase checks the basic functionality of the unlink(2).
+ * 1) unlink() can delete regular file successfully.
+ * 2) unlink() can delete fifo file successfully.
+ */
+
+#include <errno.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <stdio.h>
+#include "tst_test.h"
+
+static void file_create(char *);
+static void fifo_create(char *);
+
+#define C_FILE "/tmp/unlink05_file"
+#define C_FIFO "/tmp/unlink05_fifo"
+
+static struct test_case_t {
+	void (*setupfunc)(char *);
+	char *desc;
+} tcases[] = {
+	{file_create, C_FILE},
+	{fifo_create, C_FIFO},
+};
+
+static void file_create(char *name)
+{
+	name = C_FILE;
+	SAFE_TOUCH(name, 0777, NULL);
+}
+
+static void fifo_create(char *name)
+{
+	name = C_FIFO;
+	SAFE_MKFIFO(name, 0777);
+}
+
+static void verify_unlink(unsigned int n)
+{
+	char fname[255];
+	struct test_case_t *tc = &tcases[n];
+	tc->setupfunc(fname);
+	tst_res(TPASS, "No Test function defined here");
+}
+
+static struct tst_test test = {
+	.needs_tmpdir = 1,
+	.tcnt = ARRAY_SIZE(tcases),
+	.test = verify_unlink,
+};

--- a/ltp_src/testcases/kernel/syscalls/unlink/unlink07_run.c
+++ b/ltp_src/testcases/kernel/syscalls/unlink/unlink07_run.c
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) 2000 Silicon Graphics, Inc.  All Rights Reserved.
+ */
+
+/*
+ * Description:
+ * The testcase checks the various errnos of the unlink(2).
+ * 1) unlink() returns ENOENT if file doesn't exist.
+ * 2) unlink() returns ENOENT if path is empty.
+ * 3) unlink() returns ENOENT if path contains a non-existent file.
+ * 4) unlink() returns EFAULT if address is invalid.
+ * 5) unlink() returns ENOTDIR if path contains a regular file.
+ * 6) unlink() returns ENAMETOOLONG if path contains a regular file.
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/param.h>	/* for PATH_MAX */
+#include "tst_test.h"
+
+static char longpathname[PATH_MAX + 2];
+
+static struct test_case_t {
+	char *name;
+	char *desc;
+	int exp_errno;
+} tcases[] = {
+	{"nonexistfile", "non-existent file", ENOENT},
+	{"", "path is empty string", ENOENT},
+	{"nefile/file", "path contains a non-existent file", ENOENT},
+	{NULL, "invalid address", EFAULT},
+	{"/tmp/unlink07_file/file", "path contains a regular file", ENOTDIR},
+	{longpathname, "pathname too long", ENAMETOOLONG},
+};
+
+static void verify_unlink(unsigned int n)
+{
+	struct test_case_t *tc = &tcases[n];
+
+	TEST(unlink(tc->name));
+	if (TST_RET != -1) {
+		tst_res(TFAIL, "unlink(<%s>) succeeded unexpectedly",
+			tc->desc);
+		return;
+	}
+
+	if (TST_ERR == tc->exp_errno) {
+		tst_res(TPASS | TTERRNO, "unlink(<%s>) failed as expected",
+			tc->desc);
+	} else {
+		tst_res(TFAIL | TTERRNO,
+			"unlink(<%s>) failed, expected errno: %s",
+			tc->desc, tst_strerrno(tc->exp_errno));
+	}
+}
+
+static void setup(void)
+{
+	unsigned int n;
+
+	memset(longpathname, 'a', PATH_MAX + 2);
+
+	for (n = 0; n < ARRAY_SIZE(tcases); n++) {
+		if (!tcases[n].name)
+			tcases[n].name = tst_get_bad_addr(NULL);
+	}
+}
+
+static struct tst_test test = {
+	.needs_tmpdir = 1,
+	.setup = setup,
+	.tcnt = ARRAY_SIZE(tcases),
+	.test = verify_unlink,
+};

--- a/ltp_src/testcases/kernel/syscalls/unlink/unlink07_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/unlink/unlink07_setup.c
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) 2000 Silicon Graphics, Inc.  All Rights Reserved.
+ */
+
+/*
+ * Description:
+ * The testcase checks the various errnos of the unlink(2).
+ * 1) unlink() returns ENOENT if file doesn't exist.
+ * 2) unlink() returns ENOENT if path is empty.
+ * 3) unlink() returns ENOENT if path contains a non-existent file.
+ * 4) unlink() returns EFAULT if address is invalid.
+ * 5) unlink() returns ENOTDIR if path contains a regular file.
+ * 6) unlink() returns ENAMETOOLONG if path contains a regular file.
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/param.h>	/* for PATH_MAX */
+#include "tst_test.h"
+
+static char longpathname[PATH_MAX + 2];
+
+static struct test_case_t {
+	char *name;
+	char *desc;
+	int exp_errno;
+} tcases[] = {
+	{"nonexistfile", "non-existent file", ENOENT},
+	// {"", "path is empty string", ENOENT},
+	// {"nefile/file", "path contains a non-existent file", ENOENT},
+	// {NULL, "invalid address", EFAULT},
+	// {"file/file", "path contains a regular file", ENOTDIR},
+	// {longpathname, "pathname too long", ENAMETOOLONG},
+};
+
+static void verify_unlink(unsigned int n)
+{
+	tst_res(TPASS, "No Test function defined here");
+}
+
+static void setup(void)
+{
+	unsigned int n;
+
+	SAFE_TOUCH("/tmp/unlink07_file", 0777, NULL);
+
+	// memset(longpathname, 'a', PATH_MAX + 2);
+
+	// for (n = 0; n < ARRAY_SIZE(tcases); n++) {
+	// 	if (!tcases[n].name)
+	// 		tcases[n].name = tst_get_bad_addr(NULL);
+	// }
+}
+
+static struct tst_test test = {
+	.needs_tmpdir = 1,
+	.setup = setup,
+	.tcnt = ARRAY_SIZE(tcases),
+	.test = verify_unlink,
+};

--- a/ltp_src/testcases/kernel/syscalls/unlink/unlink08_run.c
+++ b/ltp_src/testcases/kernel/syscalls/unlink/unlink08_run.c
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) 2000 Silicon Graphics, Inc.  All Rights Reserved.
+ */
+
+/*
+ * Description:
+ * The testcase checks the various errnos of the unlink(2).
+ * 1) unlink() returns EACCES when deleting file in unwritable directory
+ *    as an unprivileged user.
+ * 2) unlink() returns EACCES when deleting file in "unsearchable directory
+ *    as an unprivileged user.
+ * 3) unlink() returns EISDIR when deleting directory for root
+ * 4) unlink() returns EISDIR when deleting directory for regular user
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include "tst_test.h"
+
+static struct passwd *pw;
+
+static struct test_case_t {
+	char *name;
+	char *desc;
+	int exp_errno;
+	int exp_user;
+} tcases[] = {
+	{"/tmp/unwrite_dir/file", "unwritable directory", EACCES, 1},
+	{"/tmp/unsearch_dir/file", "unsearchable directory", EACCES, 1},
+	{"/tmp/regdir", "directory", EISDIR, 0},
+	{"/tmp/regdir", "directory", EISDIR, 1},
+};
+
+static void verify_unlink(struct test_case_t *tc)
+{
+	TEST(unlink(tc->name));
+	if (TST_RET != -1) {
+		tst_res(TFAIL, "unlink(<%s>) succeeded unexpectedly",
+			tc->desc);
+		return;
+	}
+
+	if (TST_ERR == tc->exp_errno) {
+		tst_res(TPASS | TTERRNO, "unlink(<%s>) failed as expected",
+			tc->desc);
+	} else {
+		tst_res(TFAIL | TTERRNO,
+			"unlink(<%s>) failed, expected errno: %s",
+			tc->desc, tst_strerrno(tc->exp_errno));
+	}
+}
+
+static void do_unlink(unsigned int n)
+{
+	struct test_case_t *cases = &tcases[n];
+	pid_t pid;
+
+	if (cases->exp_user) {
+		pid = SAFE_FORK();
+		if (!pid) {
+			SAFE_SETUID(pw->pw_uid);
+			verify_unlink(cases);
+			exit(0);
+		}
+
+		SAFE_WAITPID(pid, NULL, 0);
+	} else {
+		verify_unlink(cases);
+	}
+}
+
+static void setup(void)
+{
+	pw = SAFE_GETPWNAM("nobody");
+}
+
+static struct tst_test test = {
+	.needs_root = 1,
+	.forks_child = 1,
+	.needs_tmpdir = 1,
+	.setup = setup,
+	.tcnt = ARRAY_SIZE(tcases),
+	.test = do_unlink,
+};

--- a/ltp_src/testcases/kernel/syscalls/unlink/unlink08_setup.c
+++ b/ltp_src/testcases/kernel/syscalls/unlink/unlink08_setup.c
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) 2000 Silicon Graphics, Inc.  All Rights Reserved.
+ */
+
+/*
+ * Description:
+ * The testcase checks the various errnos of the unlink(2).
+ * 1) unlink() returns EACCES when deleting file in unwritable directory
+ *    as an unprivileged user.
+ * 2) unlink() returns EACCES when deleting file in "unsearchable directory
+ *    as an unprivileged user.
+ * 3) unlink() returns EISDIR when deleting directory for root
+ * 4) unlink() returns EISDIR when deleting directory for regular user
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include "tst_test.h"
+
+static struct passwd *pw;
+
+static struct test_case_t {
+	char *name;
+	char *desc;
+	int exp_errno;
+	int exp_user;
+} tcases[] = {
+	{"/tmp/unwrite_dir/file", "unwritable directory", EACCES, 1},
+};
+
+static void verify_unlink(struct test_case_t *tc)
+{
+	TEST(unlink(tc->name));
+	if (TST_RET != -1) {
+		tst_res(TFAIL, "unlink(<%s>) succeeded unexpectedly",
+			tc->desc);
+		return;
+	}
+
+	if (TST_ERR == tc->exp_errno) {
+		tst_res(TPASS | TTERRNO, "unlink(<%s>) failed as expected",
+			tc->desc);
+	} else {
+		tst_res(TFAIL | TTERRNO,
+			"unlink(<%s>) failed, expected errno: %s",
+			tc->desc, tst_strerrno(tc->exp_errno));
+	}
+}
+
+static void do_unlink(unsigned int n)
+{
+	tst_res(TPASS, "No Test Function defined here");
+}
+
+static void setup(void)
+{
+	SAFE_MKDIR("/tmp/unwrite_dir", 0777);
+	SAFE_TOUCH("/tmp/unwrite_dir/file", 0777, NULL);
+	SAFE_CHMOD("/tmp/unwrite_dir", 0555);
+
+	SAFE_MKDIR("/tmp/unsearch_dir", 0777);
+	SAFE_TOUCH("/tmp/unsearch_dir/file", 0777, NULL);
+	SAFE_CHMOD("/tmp/unsearch_dir", 0666);
+
+	SAFE_MKDIR("/tmp/regdir", 0777);
+
+}
+
+static struct tst_test test = {
+	.needs_root = 1,
+	.forks_child = 1,
+	.needs_tmpdir = 1,
+	.setup = setup,
+	.tcnt = ARRAY_SIZE(tcases),
+	.test = do_unlink,
+};


### PR DESCRIPTION
In this commit, the run testcases are added as a part of LTP upgrade process.
The must pass condition (number 6 and 7) for clock_nanosleep01 is removed as it is giving TCONF when run without gramine on Ubuntu.