### PR TITLE
Increasing PAL internal memory size and timeout for Bash example

### DIFF
--- a/ci/stage-test-sgx.jenkinsfile
+++ b/ci/stage-test-sgx.jenkinsfile
@@ -31,10 +31,14 @@ stage('test-sgx') {
 
 
     try{
-        timeout(time: 5, unit: 'MINUTES') {
+        timeout(time: 10, unit: 'MINUTES') {
             sh '''
                 cd CI-Examples/bash
                 sed -i '/@rm OUTPUT/d' Makefile
+                if [ "${gcc_dump_machine}" == 'x86_64-redhat-linux' ]
+                then
+                    sed -i '$ a loader.pal_internal_mem_size = "128M"' manifest.template 
+                fi                    
                 make ${MAKEOPTS} ${ARCH_LIB_OPT} all
                 make ${MAKEOPTS} SGX=1 regression
             '''


### PR DESCRIPTION
In this commit, the pal_internal_mem_size is increased by 128 MB and timeout to 10 minutes as required by Bash example.