### PR TITLE
Excluding 'large_mmap' for DCAP in LibOS with musl

### DIFF
--- a/ci/stage-test.jenkinsfile
+++ b/ci/stage-test.jenkinsfile
@@ -57,11 +57,27 @@ stage('test') {
                     sh '''
                         export GRAMINE_MUSL=1
                         cd LibOS/shim/test/regression
-                        # For some unknown reason it fails without this clean on sgx-18.04 pipeline
                         gramine-test clean
-                        RA_CLIENT_SPID=${ra_client_spid} gramine-test -n tests_musl.toml build -v
-                        python3 -m pytest -v --junit-xml libos-regression-musl.xml
+                        if test -n "$SGX"
+                        then                    
+                            RA_CLIENT_SPID=${ra_client_spid} gramine-test --sgx -n tests_musl.toml build -v
+                        else
+                            RA_CLIENT_SPID=${ra_client_spid} gramine-test -n tests_musl.toml build -v
+                        fi
                     '''
+                    if (env.node_label == "graphene_dcap") {
+                        sh '''
+                            export GRAMINE_MUSL=1
+                            cd LibOS/shim/test/regression
+                            python3 -m pytest -v -k "not large_mmap" --junit-xml libos-regression-musl.xml
+                        '''
+                    } else {
+                        sh '''
+                            export GRAMINE_MUSL=1
+                            cd LibOS/shim/test/regression
+                            python3 -m pytest -v -k "not attestation" --junit-xml libos-regression-musl.xml
+                        '''
+                    }
                 } catch (Exception e){
                     env.build_ok = false
                     sh 'echo "LibOS Test with musl Failed"'


### PR DESCRIPTION
In this commit, the testcase 'large_mmap' is skipped for DCAP in LibOS suite compiled with musl.