### PR TITLE
Removing -n4 option

### DIFF
--- a/ci/stage-test-direct.jenkinsfile
+++ b/ci/stage-test-direct.jenkinsfile
@@ -11,7 +11,7 @@ stage('test-direct') {
             // separately
             sh '''
                 cd LibOS/shim/test/ltp
-                python3 -m pytest -v -n4 --junit-xml=ltp.xml
+                python3 -m pytest -v  --junit-xml=ltp.xml
             '''            
             /*
             sh '''


### PR DESCRIPTION
In this commit, "-n4" option is removed for LTP with direct, as it is not supported on CentOS machines