### PR TITLE
Adding libtinfo specifically for CentOS docker configuration

### DIFF
--- a/ci/linux-sgx-centos8-docker-gcc-release.jenkinsfile
+++ b/ci/linux-sgx-centos8-docker-gcc-release.jenkinsfile
@@ -35,7 +35,8 @@ node (node_label) {
                 $WORKSPACE/LibOS/shim/test/ltp/manifest.LTP'
                 
             sh 'sed -i \'s/bash -c "ls"/bash -c "free"/g\' CI-Examples/bash/Makefile'
-            sh 'sed -i \'s/readlink/total/g\' test_workloads.py'                
+            sh 'sed -i \'s/readlink/total/g\' test_workloads.py'
+            sh 'sed -i \'/sgx.trusted_files/ a "file:{{ arch_libdir }}/libtinfo.so.6",\' LibOS/shim/test/ltp/manifest.template'
 
             load '../ci/config-docker.jenkinsfile'
             docker.build(

--- a/ltp_config/manifest.LTP
+++ b/ltp_config/manifest.LTP
@@ -63,7 +63,6 @@ sgx.trusted_files.librt = "file:{{ gramine.runtimedir() }}/librt.so.1"
 sgx.trusted_files.libstdbuf = "file:{{ coreutils_libdir }}/libstdbuf.so"
 sgx.trusted_files.glibclibnssfiles = "file:{{ gramine.runtimedir() }}/libnss_files.so.2"
 sgx.trusted_files.libnssfiles = "file:{{ arch_libdir }}/libnss_files.so.2"
-sgx.trusted_files.libtinfo = "file:{{ arch_libdir }}/libtinfo.so.6"
 
 sgx.allowed_files.tmp = "file:/tmp"
 sgx.allowed_files.etc = "file:etc"

--- a/ltp_config/manifest.template
+++ b/ltp_config/manifest.template
@@ -81,6 +81,5 @@ sgx.trusted_files = [
   "file:{{ coreutils_libdir }}/libstdbuf.so",
   "file:{{ gramine.runtimedir() }}/libnss_files.so.2",
   "file:{{ arch_libdir }}/libnss_files.so.2",
-  "file:{{ arch_libdir }}/libtinfo.so.6",
 ]
 


### PR DESCRIPTION
In this commit, the libtinfo is added via sed command in manifest file of LTP specifically for CentOS docker.