### PR TITLE
Updating ltp_tests.cfg

### DIFF
--- a/ltp_config/ltp_tests.cfg
+++ b/ltp_config/ltp_tests.cfg
@@ -231,24 +231,9 @@ skip = yes
 [eventfd2_*]
 skip = yes
 
-# BROK: Test haven't reported results
-[execl01]
-must-pass =
-    1
-
 # error while loading libc.so.6
 [execle01]
 skip = yes
-
-# BROK: Test haven't reported results
-[execlp01]
-must-pass =
-    1
-
-# BROK: Test haven't reported results
-[execv01]
-must-pass =
-    1
 
 # error while loading libc.so.6
 [execve01]
@@ -285,11 +270,6 @@ skip = yes
 # copy child
 [execveat03]
 skip = yes
-
-# BROK: Test haven't reported results
-[execvp01]
-must-pass =
-    1
 
 [faccessat01]
 timeout = 80
@@ -1203,12 +1183,6 @@ skip = yes
 [munlock02]
 skip = yes
 
-# reports TBROK due to lack of reported results (no shared memory in Gramine)
-[nanosleep02]
-must-pass = 
-    1
-    2
-
 [nftw01]
 skip = yes
 
@@ -1989,10 +1963,6 @@ must-pass =
 [setrlimit03]
 must-pass =
     2
-
-[setrlimit05]
-must-pass =
-    1
 
 [setrlimit06]
 skip = yes


### PR DESCRIPTION
In this commit, the above mentioned file is changed corresponding to commit "[LibOS] Re-map tainted shared file-backed memory regions on fork".