### PR TITLE
Adding the must pass condition for failing LTP testcases with SGX

### DIFF
--- a/ltp_config/ltp-sgx_tests.cfg
+++ b/ltp_config/ltp-sgx_tests.cfg
@@ -33,6 +33,26 @@ skip = yes
 [epoll_wait01]
 skip = yes
 
+# BROK: Test haven't reported results
+[execl01]
+must-pass =
+    1
+
+# BROK: Test haven't reported results
+[execlp01]
+must-pass =
+    1
+
+# BROK: Test haven't reported results
+[execv01]
+must-pass =
+    1
+
+# BROK: Test haven't reported results
+[execvp01]
+must-pass =
+    1
+
 [fork06]
 skip = yes
 


### PR DESCRIPTION
In this commit, the must pass condition is added for LTP testcases, i.e. execl01, execlp01, execv01 and execvp01 as the TBROK errors were fixed for gramine-direct and not for SGX with the commit "[LibOS] Re-map tainted shared file-backed memory regions on fork".