### PR TITLE
Enabling fstat03

### DIFF
--- a/ltp_config/ltp_tests.cfg
+++ b/ltp_config/ltp_tests.cfg
@@ -541,15 +541,6 @@ skip = yes
 [fspick*]
 skip = yes
 
-# TBROK: Test 0 haven't reported results
-[fstat03]
-must-pass = 
-    1
-
-[fstat03_64]
-must-pass = 
-    1
-    
 # tries to mount a filesystem
 [fsync01]
 skip = yes


### PR DESCRIPTION
In this commit, fstat03 is enabled after the fix for internal memory issue with must pass all for gramine-direct.