### PR TITLE
Increasing Sandstone timeout

### DIFF
--- a/ci/stage-test-sgx.jenkinsfile
+++ b/ci/stage-test-sgx.jenkinsfile
@@ -240,7 +240,7 @@ stage('test-sgx') {
     }    
 
     try{
-        timeout(time: 90, unit: 'MINUTES') {
+        timeout(time: 120, unit: 'MINUTES') {
             sh '''
                 if [ "${no_cpu}" -gt 16 ]
                 then


### PR DESCRIPTION
In this commit, the timeout for sandstone is increased to 120.