### PR TITLE
Changes to LTP suite and proxy for GSC CentOS configuration

### DIFF
--- a/gsc/test/centos8-bash.dockerfile
+++ b/gsc/test/centos8-bash.dockerfile
@@ -3,7 +3,7 @@ From centos:8
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* &&\
     sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
 
-RUN echo 'proxy=http://proxy-chain.intel.com:911' >> /etc/yum.conf
+RUN echo 'proxy=http://proxy-dmz.intel.com:911' >> /etc/yum.conf
 
 RUN yum update -y
 

--- a/ltp_config/ltp-sgx_tests.cfg
+++ b/ltp_config/ltp-sgx_tests.cfg
@@ -122,6 +122,10 @@ skip = yes
 [madvise10]
 skip = yes
 
+# Gramine Issue #401
+[mincore01]
+skip = yes
+
 [mknod02]
 skip = yes
 
@@ -158,6 +162,10 @@ timeout = 60
 [mmap05]
 skip = yes
 
+# Gramine Issue #401
+[mmap09]
+skip = yes
+
 [mmap13]
 skip = yes
 
@@ -186,12 +194,9 @@ skip = yes
 skip = yes
 
 # 2 sub-tests fail with MS_INVALIDATE and MS_SYNC unsupported flag
+# Gramine Issue #401
 [msync03]
-must-pass =
-    2
-    3
-    4
-    5
+skip = yes
 
 [munmap01]
 skip = yes
@@ -276,6 +281,10 @@ must-pass =
 [pwritev01]
 skip = yes
 timeout = 60
+
+# Gramine issue #401
+[qmm01]
+skip = yes
 
 [read01]
 timeout = 60

--- a/ltp_config/ltp_tests.cfg
+++ b/ltp_config/ltp_tests.cfg
@@ -1250,6 +1250,12 @@ skip = yes
 # uses futexes on memory shared between processes
 [pause01]
 skip = yes
+# not supported in Gramine
+[pause02]
+skip = yes
+# not supported in Gramine
+[pause03]
+skip = yes
 
 [perf_event_open01]
 skip = yes

--- a/ltp_src/testcases/kernel/syscalls/epoll_pwait/epoll_pwait.h
+++ b/ltp_src/testcases/kernel/syscalls/epoll_pwait/epoll_pwait.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016 Fujitsu Ltd.
+ * Author: Guangwen Feng <fenggw-fnst@cn.fujitsu.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ */
+
+#ifndef EPOLL_PWAIT_H
+#define EPOLL_PWAIT_H
+
+#include <sys/types.h>
+#include <signal.h>
+#include "config.h"
+#include "lapi/syscalls.h"
+
+#if !defined(HAVE_EPOLL_PWAIT)
+int epoll_pwait(int epfd, struct epoll_event *events, int maxevents,
+	int timeout, const sigset_t *sigmask)
+{
+	return ltp_syscall(__NR_epoll_pwait, epfd, events, maxevents,
+		timeout, sigmask, _NSIG / 8);
+}
+#endif
+
+#endif /* EPOLL_PWAIT_H */

--- a/ltp_src/testcases/kernel/syscalls/epoll_pwait/epoll_pwait01.c
+++ b/ltp_src/testcases/kernel/syscalls/epoll_pwait/epoll_pwait01.c
@@ -1,127 +1,197 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * Copyright (c) 2016 Fujitsu Ltd.
  * Author: Guangwen Feng <fenggw-fnst@cn.fujitsu.com>
- * Copyright (c) 2021 Xie Ziyao <xieziyao@huawei.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
  */
 
-/*\
- * [Description]
- *
- * Basic test for epoll_pwait() and epoll_pwait2().
- *
- * - With a sigmask a signal is ignored and the syscall safely waits until
- *   either a file descriptor becomes ready or the timeout expires.
- *
- * - Without sigmask if signal arrives a syscall is iterrupted by a signal.
- *   The call should return -1 and set errno to EINTR.
+/*
+ * Description:
+ *  Basic test for epoll_pwait(2).
+ *  1) epoll_pwait(2) with sigmask argument allows the caller to
+ *     safely wait until either a file descriptor becomes ready
+ *     or the timeout expires.
+ *  2) epoll_pwait(2) with NULL sigmask argument fails if
+ *     interrupted by a signal handler, epoll_pwait(2) should
+ *     return -1 and set errno to EINTR.
  */
 
-#include <stdlib.h>
 #include <sys/epoll.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
 
-#include "tst_test.h"
-#include "epoll_pwait_var.h"
+#include "test.h"
+#include "epoll_pwait.h"
+#include "safe_macros.h"
 
-static int efd, sfd[2];
-static struct epoll_event e;
+char *TCID = "epoll_pwait01";
+int TST_TOTAL = 2;
+
+static int epfd, fds[2];
 static sigset_t signalset;
+static struct epoll_event epevs;
 static struct sigaction sa;
 
-static void sighandler(int sig LTP_ATTRIBUTE_UNUSED) {}
+static void setup(void);
+static void verify_sigmask(void);
+static void verify_nonsigmask(void);
+static void sighandler(int sig LTP_ATTRIBUTE_UNUSED);
+static void do_test(sigset_t *);
+static void do_child(void);
+static void cleanup(void);
 
-static void verify_sigmask(void)
+int main(int ac, char **av)
 {
-	TEST(do_epoll_pwait(efd, &e, 1, -1, &signalset));
+	int lc;
 
-	if (TST_RET != 1) {
-		tst_res(TFAIL, "do_epoll_pwait() returned %li, expected 1",
-			TST_RET);
-		return;
+	tst_parse_opts(ac, av, NULL, NULL);
+
+	setup();
+
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+		tst_count = 0;
+
+		do_test(&signalset);
+		do_test(NULL);
 	}
 
-	tst_res(TPASS, "do_epoll_pwait() with sigmask blocked signal");
-}
-
-static void verify_nonsigmask(void)
-{
-	TST_EXP_FAIL(do_epoll_pwait(efd, &e, 1, -1, NULL), EINTR,
-		     "do_epoll_pwait() without sigmask");
-}
-
-static void (*testcase_list[])(void) = {verify_sigmask, verify_nonsigmask};
-
-static void run(unsigned int n)
-{
-	char b;
-	pid_t pid;
-
-	if (!SAFE_FORK()) {
-		pid = getppid();
-
-		TST_PROCESS_STATE_WAIT(pid, 'S', 0);
-		SAFE_KILL(pid, SIGUSR1);
-
-		usleep(10000);
-		SAFE_WRITE(1, sfd[1], "w", 1);
-		exit(0);
-	}
-
-	testcase_list[n]();
-
-	SAFE_READ(1, sfd[0], &b, 1);
-	tst_reap_children();
-}
-
-static void epoll_pwait_support(void)
-{
-	if (tst_variant == 0)
-		epoll_pwait_supported();
-	else
-		epoll_pwait2_supported();
+	cleanup();
+	tst_exit();
 }
 
 static void setup(void)
 {
-	SAFE_SIGEMPTYSET(&signalset);
-	SAFE_SIGADDSET(&signalset, SIGUSR1);
+	if ((tst_kvercmp(2, 6, 19)) < 0) {
+		tst_brkm(TCONF, NULL, "This test can only run on kernels "
+			 "that are 2.6.19 or higher");
+	}
+
+	tst_sig(FORK, DEF_HANDLER, cleanup);
+
+	TEST_PAUSE;
+
+	if (sigemptyset(&signalset) == -1)
+		tst_brkm(TFAIL | TERRNO, NULL, "sigemptyset() failed");
+
+	if (sigaddset(&signalset, SIGUSR1) == -1)
+		tst_brkm(TFAIL | TERRNO, NULL, "sigaddset() failed");
 
 	sa.sa_flags = 0;
 	sa.sa_handler = sighandler;
-	SAFE_SIGEMPTYSET(&sa.sa_mask);
-	SAFE_SIGACTION(SIGUSR1, &sa, NULL);
+	if (sigemptyset(&sa.sa_mask) == -1)
+		tst_brkm(TFAIL | TERRNO, NULL, "sigemptyset() failed");
 
-	epoll_pwait_info();
-	epoll_pwait_support();
+	if (sigaction(SIGUSR1, &sa, NULL) == -1)
+		tst_brkm(TFAIL | TERRNO, NULL, "sigaction() failed");
 
-	SAFE_SOCKETPAIR(AF_UNIX, SOCK_STREAM, 0, sfd);
+	SAFE_PIPE(NULL, fds);
 
-	efd = epoll_create(1);
-	if (efd == -1)
-		tst_brk(TBROK | TERRNO, "epoll_create()");
+	epfd = epoll_create(1);
+	if (epfd == -1) {
+		tst_brkm(TBROK | TERRNO, cleanup,
+			 "failed to create epoll instance");
+	}
 
-	e.events = EPOLLIN;
-	if (epoll_ctl(efd, EPOLL_CTL_ADD, sfd[0], &e))
-		tst_brk(TBROK | TERRNO, "epoll_clt(..., EPOLL_CTL_ADD, ...)");
+	epevs.events = EPOLLIN;
+	epevs.data.fd = fds[0];
+
+	if (epoll_ctl(epfd, EPOLL_CTL_ADD, fds[0], &epevs) == -1) {
+		tst_brkm(TBROK | TERRNO, cleanup,
+			 "failed to register epoll target");
+	}
+}
+
+static void verify_sigmask(void)
+{
+	if (TEST_RETURN == -1) {
+		tst_resm(TFAIL | TTERRNO, "epoll_pwait() failed");
+		return;
+	}
+
+	if (TEST_RETURN != 0) {
+		tst_resm(TFAIL, "epoll_pwait() returned %li, expected 0",
+			 TEST_RETURN);
+		return;
+	}
+
+	tst_resm(TPASS, "epoll_pwait(sigmask) blocked signal");
+}
+
+static void verify_nonsigmask(void)
+{
+	if (TEST_RETURN != -1) {
+		tst_resm(TFAIL, "epoll_wait() succeeded unexpectedly");
+		return;
+	}
+
+	if (TEST_ERRNO == EINTR) {
+		tst_resm(TPASS | TTERRNO, "epoll_wait() failed as expected");
+	} else {
+		tst_resm(TFAIL | TTERRNO, "epoll_wait() failed unexpectedly, "
+				 "expected EINTR");
+	}
+}
+
+static void sighandler(int sig LTP_ATTRIBUTE_UNUSED)
+{
+
+}
+
+static void do_test(sigset_t *sigmask)
+{
+	pid_t cpid;
+
+	cpid = tst_fork();
+	if (cpid < 0)
+		tst_brkm(TBROK | TERRNO, cleanup, "fork() failed");
+
+	if (cpid == 0)
+		do_child();
+
+	TEST(epoll_pwait(epfd, &epevs, 1, 100, sigmask));
+
+	if (sigmask != NULL)
+		verify_sigmask();
+	else
+		verify_nonsigmask();
+
+	tst_record_childstatus(cleanup, cpid);
+}
+
+static void do_child(void)
+{
+	if (tst_process_state_wait2(getppid(), 'S') != 0) {
+		tst_brkm(TBROK | TERRNO, cleanup,
+			 "failed to wait for parent process's state");
+	}
+
+	SAFE_KILL(cleanup, getppid(), SIGUSR1);
+
+	cleanup();
+	tst_exit();
 }
 
 static void cleanup(void)
 {
-	if (efd > 0)
-		SAFE_CLOSE(efd);
+	if (epfd > 0 && close(epfd))
+		tst_resm(TWARN | TERRNO, "failed to close epfd");
 
-	if (sfd[0] > 0)
-		SAFE_CLOSE(sfd[0]);
+	if (close(fds[0]))
+		tst_resm(TWARN | TERRNO, "close(fds[0]) failed");
 
-	if (sfd[1] > 0)
-		SAFE_CLOSE(sfd[1]);
+	if (close(fds[1]))
+		tst_resm(TWARN | TERRNO, "close(fds[1]) failed");
 }
-
-static struct tst_test test = {
-	.test = run,
-	.setup = setup,
-	.cleanup = cleanup,
-	.forks_child = 1,
-	.test_variants = TEST_VARIANTS,
-	.tcnt = ARRAY_SIZE(testcase_list),
-};


### PR DESCRIPTION
In this commit, following changes are carried out for LTP:
1. pause02 and pause03 are skipped for G-Direct and GSGX.
2. qmm01, mmap09, msync03 and mincore01 are skipped for SGX.
3. epoll_pwait01 is restored from old LTP suite.

In addition, "dmz" proxy is used for CentOS GSC.