### PR TITLE
SGX TBROK change, pipe2_02 and select03

### DIFF
--- a/ltp_config/ltp-sgx_tests.cfg
+++ b/ltp_config/ltp-sgx_tests.cfg
@@ -79,7 +79,10 @@ must-pass =
 
 [futex_wait03]
 skip = yes
-    
+
+[getpid01]
+timeout = 90
+
 [getsid01]
 skip = yes
 

--- a/ltp_config/ltp_tests.cfg
+++ b/ltp_config/ltp_tests.cfg
@@ -1745,6 +1745,9 @@ skip = yes
 [sched_setscheduler03]
 skip = yes
 
+[select03]
+skip = yes
+
 [select04]
 timeout = 60
 

--- a/ltp_config/manifest.template
+++ b/ltp_config/manifest.template
@@ -81,5 +81,10 @@ sgx.trusted_files = [
   "file:{{ coreutils_libdir }}/libstdbuf.so",
   "file:{{ gramine.runtimedir() }}/libnss_files.so.2",
   "file:{{ arch_libdir }}/libnss_files.so.2",
+  "file:{{ arch_libdir }}/libselinux.so.1",
+  "file:{{ arch_libdir }}/libacl.so.1",
+  "file:{{ arch_libdir }}/libattr.so.1",
+  "file:{{ arch_libdir }}/libpcre2-8.so.0",
+  "file:{{ arch_libdir }}/libtinfo.so.6",
 ]
 


### PR DESCRIPTION
In this commit, following changes are done:
1. Increase timeout of getpid01.
2. Pass for TBROK issue for SGX in case of getpid01 and getppid02.
3. Skip select03 for gramine-direct and gramine-sgx.
4. Files required for pipe2_02 are added in trusted SGX section.