### PR TITLE
Updating stress-ng Makefile and manifest file.

### DIFF
--- a/stress-ng/Makefile
+++ b/stress-ng/Makefile
@@ -2,7 +2,6 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 #GRAMINEDIR = ../..
 GRAMINEDIR ?= $(THIS_DIR)../..
-SGX_SIGNER_KEY ?= $(GRAMINEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
 GRAMINE_LOG_LEVEL = debug
@@ -26,7 +25,6 @@ stress-ng.manifest: stress-ng.manifest.template
 
 stress-ng.manifest.sgx: stress-ng.manifest
 			gramine-sgx-sign \
-			--key $(SGX_SIGNER_KEY) \
 			--manifest $< --output $@
 
 stress-ng.sig: stress-ng.manifest.sgx

--- a/stress-ng/stress-ng.manifest.template
+++ b/stress-ng/stress-ng.manifest.template
@@ -6,10 +6,10 @@ sys.stack.size = "8M"
 sgx.enclave_size = "4G"
 sgx.thread_num = 512
 
-sgx.nonpie_binary = 1
-loader.insecure__use_cmdline_argv = 1
-loader.insecure__use_host_env = 1
-loader.insecure__disable_aslr = 1
+sgx.nonpie_binary = true
+loader.insecure__use_cmdline_argv = true
+loader.insecure__use_host_env = true
+loader.insecure__disable_aslr = true
 
 loader.preload = "file:{{ gramine.libos }}"
 loader.env.PATH = "/usr/bin:/bin"
@@ -17,29 +17,14 @@ loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/lib/x86_64-linux-gnu"
 
 fs.experimental__enable_sysfs_topology = true
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
-
-fs.mount.bin.type = "chroot"
-fs.mount.bin.path = "/bin"
-fs.mount.bin.uri = "file:/bin"
-
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "{{ arch_libdir }}"
-fs.mount.lib2.uri = "file:{{ arch_libdir }}"
-
-fs.mount.lib3.type = "chroot"
-fs.mount.lib3.path = "/usr/{{ arch_libdir }}"
-fs.mount.lib3.uri = "file:/usr/{{ arch_libdir }}"
-
-fs.mount.tmp.type = "chroot"
-fs.mount.tmp.path = "/tmp"
-fs.mount.tmp.uri = "file:/tmp"
-
-fs.mount.stressng.type = "chroot"
-fs.mount.stressng.path = "/usr/bin"
-fs.mount.stressng.uri  = "file:/usr/bin"
+fs.mounts = [  
+  { path = "/bin", uri = "file:/bin" },
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+  { path = "/usr/{{ arch_libdir }}", uri = "file:/usr/{{ arch_libdir }}" },
+  { path = "/usr/bin", uri = "file:/usr/bin" },
+  { path = "/tmp", uri = "file:/tmp" },
+]
 
 sgx.file_check_policy = "allow_all_but_log"
 


### PR DESCRIPTION
In this commit, manifest file for stress-ng is updated as per the new format and manifest file is updated to use 
gramine-sgx-gen-private-key.