### PR TITLE
Drop support for loader.preload in manifests

### DIFF
--- a/rust_helloworld/hello.manifest.template
+++ b/rust_helloworld/hello.manifest.template
@@ -1,4 +1,4 @@
-loader.preload = "file:{{ gramine.libos }}"
+loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ self_exe }}"
 loader.argv0_override = "{{ self_exe }}"
 #loader.log_level = "trace"
@@ -16,6 +16,7 @@ fs.mounts = [
 
 sgx.trusted_files = [
   "file:{{ self_exe }}",
+  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir() }}/",
   "file:/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2",
   "file:{{ libdir }}/libgcc_s.so.1",

--- a/stress-ng/stress-ng.manifest.template
+++ b/stress-ng/stress-ng.manifest.template
@@ -1,3 +1,4 @@
+loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "/usr/bin/stress-ng" 
 
 loader.log_level = "error"
@@ -10,8 +11,6 @@ sgx.nonpie_binary = true
 loader.insecure__use_cmdline_argv = true
 loader.insecure__use_host_env = true
 loader.insecure__disable_aslr = true
-
-loader.preload = "file:{{ gramine.libos }}"
 loader.env.PATH = "/usr/bin:/bin"
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/lib/x86_64-linux-gnu"
 
@@ -35,6 +34,7 @@ sgx.allowed_files = [
 
 sgx.trusted_files = [
     "file:/usr/{{ arch_libdir }}/",
+    "file:{{ gramine.libos }}",
     "file:{{ arch_libdir }}/",
     "file:/usr/bin/stress-ng",
     "file:{{ gramine.runtimedir() }}/ld-linux-x86-64.so.2",


### PR DESCRIPTION
In this commit, loader.preload is removed from Rust and stress-ng.