### PR TITLE
Enabling fsync03

### DIFF
--- a/ltp_config/ltp-sgx_tests.cfg
+++ b/ltp_config/ltp-sgx_tests.cfg
@@ -73,9 +73,6 @@ must-pass =
 
 [fsync03]
 timeout = 60
-must-pass =
-    3
-    4
 
 [futex_wait03]
 skip = yes

--- a/ltp_config/ltp_tests.cfg
+++ b/ltp_config/ltp_tests.cfg
@@ -552,9 +552,6 @@ timeout = 120
 # 5. fsync() on a fifo returns EROFS, not EINVAL
 [fsync03]
 timeout = 40
-must-pass =
-    3
-    4
 
 # tries to mount a filesystem
 [fsync04]


### PR DESCRIPTION
In this commit, fsync03 is enabled following the commit "[LibOS] Make fsync() and fdatasync() a no-op on dirs"