### PR TITLE
Add nasm to meson and tests for ABI

### DIFF
--- a/ci/centos8.dockerfile
+++ b/ci/centos8.dockerfile
@@ -61,6 +61,7 @@ RUN yum update -y \
 #        linux-headers-generic \
         musl-devel \
         musl-gcc \
+        nasm \
         ninja-build \
         nss_nis \
         pkg-config \

--- a/ci/stage-test.jenkinsfile
+++ b/ci/stage-test.jenkinsfile
@@ -94,6 +94,27 @@ stage('test') {
         try {
             timeout(time: 15, unit: 'MINUTES') {
                 sh '''
+                    cd LibOS/shim/test/abi/x86_64
+                    if test -n "$SGX"
+                    then                     
+                        gramine-test --sgx build -v
+                    else
+                        gramine-test build -v
+                    fi
+                    python3 -m pytest -v --junit-xml abi.xml
+                '''
+            }
+        } catch (Exception e){
+            env.build_ok = false
+            sh 'echo "LibOS Test Failed"'
+        } finally {
+            archiveArtifacts 'LibOS/shim/test/abi/x86_64/abi.xml'
+            junit 'LibOS/shim/test/abi/x86_64/abi.xml'
+        }
+
+        try {
+            timeout(time: 15, unit: 'MINUTES') {
+                sh '''
                     cd LibOS/shim/test/fs
                     if test -n "$SGX"
                     then                     

--- a/ci/ubuntu18.04.dockerfile
+++ b/ci/ubuntu18.04.dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     lsb-release \
     musl \
     musl-tools \
+    nasm \
     net-tools \
     netcat-openbsd \
     ninja-build \

--- a/ci/ubuntu20.04.dockerfile
+++ b/ci/ubuntu20.04.dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     lsb-release \
     musl \
     musl-tools \
+    nasm \
     net-tools \
     netcat-openbsd \
     ninja-build \

--- a/ci/ubuntu21.04.dockerfile
+++ b/ci/ubuntu21.04.dockerfile
@@ -45,7 +45,8 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libipsec-mb-dev \
     lsb-release \
     musl \
-    musl-tools \    
+    musl-tools \
+    nasm \ 
     net-tools \
     netcat-openbsd \
     ninja-build \

--- a/ci/ubuntu21.10.dockerfile
+++ b/ci/ubuntu21.10.dockerfile
@@ -45,7 +45,8 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libipsec-mb-dev \
     lsb-release \
     musl \
-    musl-tools \    
+    musl-tools \ 
+    nasm \   
     net-tools \
     netcat-openbsd \
     ninja-build \

--- a/gsc/templates/centos/Dockerfile.compile.template
+++ b/gsc/templates/centos/Dockerfile.compile.template
@@ -24,6 +24,7 @@ RUN dnf update -y \
         libcurl-devel \
         libevent-devel \
         make \
+        nasm \
         ncurses-devel \
         ninja-build \
         openssl-devel \

--- a/gsc/templates/ubuntu/Dockerfile.compile.template
+++ b/gsc/templates/ubuntu/Dockerfile.compile.template
@@ -16,6 +16,7 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
         libcurl4-openssl-dev \
         libprotobuf-c-dev \
         linux-headers-generic \
+        nasm \
         ninja-build \
         pkg-config \
         protobuf-c-compiler \


### PR DESCRIPTION
In this commit, nasm is added to dockerfiles and tests for Application binary Interface (ABI) for x86_64 are also enabled.