### PR TITLE
Enabling debug mode for Python example

### DIFF
--- a/ci/stage-test-direct.jenkinsfile
+++ b/ci/stage-test-direct.jenkinsfile
@@ -45,13 +45,15 @@ stage('test-direct') {
         timeout(time: 5, unit: 'MINUTES') {
             sh '''
                 cd CI-Examples/python
-                make ${MAKEOPTS} ${ARCH_LIB_OPT} all
+                make ${MAKEOPTS} ${ARCH_LIB_OPT} DEBUG=1 all
                 make check
             '''
         }
     } catch (Exception e){
         env.build_ok = false
         sh 'echo "Python Example Test Failed"'
+    } finally {
+            archiveArtifacts 'CI-Examples/python/TEST_*'
     }
 
     try{

--- a/ci/stage-test-sgx.jenkinsfile
+++ b/ci/stage-test-sgx.jenkinsfile
@@ -83,13 +83,15 @@ stage('test-sgx') {
             timeout(time: 5, unit: 'MINUTES') {
                 sh '''
                     cd CI-Examples/python
-                    make ${MAKEOPTS} ${ARCH_LIB_OPT} all
+                    make ${MAKEOPTS} ${ARCH_LIB_OPT} DEBUG=1 all
                     make ${MAKEOPTS} SGX=1 check
                 '''
             }
         } catch (Exception e){
             env.build_ok = false
             sh 'echo "Python Example Test Failed"'
+        } finally {
+            archiveArtifacts 'CI-Examples/python/TEST_*'
         }
     }
 

--- a/ltp_config/manifest_18_04.template
+++ b/ltp_config/manifest_18_04.template
@@ -21,7 +21,6 @@ fs.mounts = [
   { path = "/dev/cpu_dma_latency", uri = "file:/dev/cpu_dma_latency" },
 ]
 
-fs.experimental__enable_sysfs_topology = true
 sys.brk.max_size = "32M"
 sys.stack.size = "4M"
 sgx.nonpie_binary = true

--- a/ltp_config/manifest_20_04_21_10.template
+++ b/ltp_config/manifest_20_04_21_10.template
@@ -21,7 +21,6 @@ fs.mounts = [
   { path = "/dev/cpu_dma_latency", uri = "file:/dev/cpu_dma_latency" },
 ]
 
-fs.experimental__enable_sysfs_topology = true
 sys.brk.max_size = "32M"
 sys.stack.size = "4M"
 sgx.nonpie_binary = true

--- a/ltp_config/manifest_CentOS_RHEL.template
+++ b/ltp_config/manifest_CentOS_RHEL.template
@@ -21,7 +21,6 @@ fs.mounts = [
   { path = "/dev/cpu_dma_latency", uri = "file:/dev/cpu_dma_latency" },
 ]
 
-fs.experimental__enable_sysfs_topology = true
 sys.brk.max_size = "32M"
 sys.stack.size = "4M"
 sgx.nonpie_binary = true


### PR DESCRIPTION
In this commit, debug mode is set for python example. Also, the error log is archived. The sysfs feature is disabled for LTP suite as per the recent commit.