### PR TITLE
Enabling FS suite testcase for renaming of a protected file

### DIFF
--- a/Patch/rename_protected_file.patch
+++ b/Patch/rename_protected_file.patch
@@ -1,0 +1,83 @@
+diff --git a/LibOS/shim/test/fs/manifest.template b/LibOS/shim/test/fs/manifest.template
+index 8eabe102..0e584615 100644
+--- a/LibOS/shim/test/fs/manifest.template
++++ b/LibOS/shim/test/fs/manifest.template
+@@ -10,7 +10,7 @@ fs.mounts = [
+   { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+   { path = "/usr/{{ arch_libdir }}", uri = "file:/usr/{{ arch_libdir }}" },
+   { path = "/mounted", uri = "file:tmp" },
+-
++  { type = "encrypted", path = "protected", uri = "file:protected" , key_name = "_sgx_mrenclave"},
+   { type = "encrypted", path = "/tmp/enc_input", uri = "file:tmp/enc_input" },
+   { type = "encrypted", path = "/tmp/enc_output", uri = "file:tmp/enc_output" },
+   { type = "encrypted", path = "/mounted/enc_input", uri = "file:tmp/enc_input" },
+diff --git a/LibOS/shim/test/fs/meson.build b/LibOS/shim/test/fs/meson.build
+index 0d064dbb..86108836 100644
+--- a/LibOS/shim/test/fs/meson.build
++++ b/LibOS/shim/test/fs/meson.build
+@@ -42,6 +42,7 @@ tests = {
+     'open_close': {},
+     'open_flags': {},
+     'read_write': {},
++    'rename_pf': {},
+     'seek_tell': {},
+     'stat': {},
+     'truncate': {},
+diff --git a/LibOS/shim/test/fs/rename_pf.c b/LibOS/shim/test/fs/rename_pf.c
+new file mode 100644
+index 00000000..95e58076
+--- /dev/null
++++ b/LibOS/shim/test/fs/rename_pf.c
+@@ -0,0 +1,22 @@
++#include <stdio.h>
++#include <stdlib.h>
++#define FILENAME "protected/data"
++
++int main(void) {
++    FILE* f;
++
++    if ((f = fopen(FILENAME, "wb")) == NULL) {
++        perror("first create failed");
++        exit(1);
++    }
++    if (fwrite("data", 1, 4, f) != 4) {
++        perror("first write failed");
++        fclose(f);
++        exit(1);
++    }
++    fclose(f);
++
++    rename(FILENAME, FILENAME ".bak");
++    printf("TEST OK\n");
++    return 0;
++}
+\ No newline at end of file
+diff --git a/LibOS/shim/test/fs/test_enc.py b/LibOS/shim/test/fs/test_enc.py
+index 77479c3a..8c73a611 100644
+--- a/LibOS/shim/test/fs/test_enc.py
++++ b/LibOS/shim/test/fs/test_enc.py
+@@ -101,6 +101,12 @@ class TC_50_EncryptedFiles(test_fs.TC_00_FileSystem):
+         stdout, stderr = self.run_binary(['open_flags', file_path])
+         self.verify_open_flags(stdout, stderr)
+ 
++    @unittest.skipIf(os.environ.get('SGX') != '1', 'Checking renaming of protected files for SGX only')
++    def test_099_rename_pf(self):
++        os.makedirs('protected', exist_ok=True)
++        stdout, stderr = self.run_binary(['rename_pf'])
++        self.assertIn('TEST OK', stdout)
++
+     # overrides TC_00_FileSystem to change input dir (from plaintext to encrypted)
+     def test_115_seek_tell(self):
+         # the test binary expects a path to read-only (existing) file and two paths to files that
+diff --git a/LibOS/shim/test/fs/tests.toml b/LibOS/shim/test/fs/tests.toml
+index 03fe2d7c..906142af 100644
+--- a/LibOS/shim/test/fs/tests.toml
++++ b/LibOS/shim/test/fs/tests.toml
+@@ -13,6 +13,7 @@ manifests = [
+   "open_close",
+   "open_flags",
+   "read_write",
++  "rename_pf",
+   "seek_tell",
+   "stat",
+   "truncate",

--- a/ci/linux-sgx-centos8-docker-gcc-release.jenkinsfile
+++ b/ci/linux-sgx-centos8-docker-gcc-release.jenkinsfile
@@ -27,6 +27,7 @@ node (node_label) {
             sh 'cp -f $WORKSPACE/test_workloads.py . '
             sh 'cp -rf $WORKSPACE/examples/* CI-Examples/'
             sh 'cp -rf $WORKSPACE/utils/openvino_setup.sh CI-Examples/openvino/'
+            sh 'cp -f $WORKSPACE/Patch/rename_protected_file.patch .'
             env.WORKSPACE = env.WORKSPACE + "/gramine"
             env.SGX = '1'
 

--- a/ci/linux-sgx-centos8.2-gcc-release.jenkinsfile
+++ b/ci/linux-sgx-centos8.2-gcc-release.jenkinsfile
@@ -27,6 +27,7 @@ node (node_label) {
             sh 'cp -f $WORKSPACE/test_workloads.py . '
             sh 'cp -rf $WORKSPACE/examples/* CI-Examples/'
             sh 'cp -rf $WORKSPACE/utils/openvino_setup.sh CI-Examples/openvino/'
+            sh 'cp -f $WORKSPACE/Patch/rename_protected_file.patch .'
             env.WORKSPACE = env.WORKSPACE + "/gramine"
             env.SGX = '1'
 

--- a/ci/linux-sgx-ubuntu18.04-gcc-release.jenkinsfile
+++ b/ci/linux-sgx-ubuntu18.04-gcc-release.jenkinsfile
@@ -29,6 +29,7 @@ node (node_label) {
             sh 'cp -f $WORKSPACE/test_workloads.py . '
             sh 'cp -rf $WORKSPACE/Python/* CI-Examples/python/'
             sh 'cp -rf $WORKSPACE/utils/openvino_setup.sh CI-Examples/openvino/'
+            sh 'cp -f $WORKSPACE/Patch/rename_protected_file.patch .'
             env.WORKSPACE = env.WORKSPACE + "/gramine"
             env.SGX = '1'
 

--- a/ci/linux-sgx-ubuntu20.04-gcc-release.jenkinsfile
+++ b/ci/linux-sgx-ubuntu20.04-gcc-release.jenkinsfile
@@ -28,6 +28,7 @@ node(node_label) {
             sh 'cp -rf ~/jenkins/sandstone-50-bin CI-Examples/'
             sh 'cp -f $WORKSPACE/test_workloads.py . '
             sh 'cp -rf $WORKSPACE/utils/openvino_setup.sh CI-Examples/openvino/'
+            sh 'cp -f $WORKSPACE/Patch/rename_protected_file.patch .'
             env.WORKSPACE = env.WORKSPACE + "/gramine"
             env.SGX = '1'
 

--- a/ci/linux-sgx-ubuntu21.04-gcc-release.jenkinsfile
+++ b/ci/linux-sgx-ubuntu21.04-gcc-release.jenkinsfile
@@ -26,6 +26,7 @@ node(node_label) {
             sh 'cp -rf $WORKSPACE/rust_helloworld CI-Examples/'
             sh 'cp -rf $WORKSPACE/examples/* CI-Examples/'
             sh 'cp -f $WORKSPACE/test_workloads.py . '
+            sh 'cp -f $WORKSPACE/Patch/rename_protected_file.patch .'
             env.WORKSPACE = env.WORKSPACE + "/gramine"
             env.SGX = '1'
 

--- a/ci/linux-sgx-ubuntu21.10-gcc-release.jenkinsfile
+++ b/ci/linux-sgx-ubuntu21.10-gcc-release.jenkinsfile
@@ -26,6 +26,7 @@ node(node_label) {
             sh 'cp -rf $WORKSPACE/rust_helloworld CI-Examples/'
             sh 'cp -rf $WORKSPACE/examples/* CI-Examples/'
             sh 'cp -f $WORKSPACE/test_workloads.py . '
+            sh 'cp -f $WORKSPACE/Patch/rename_protected_file.patch .'
             env.WORKSPACE = env.WORKSPACE + "/gramine"
             env.SGX = '1'
 

--- a/ci/stage-build-sgx.jenkinsfile
+++ b/ci/stage-build-sgx.jenkinsfile
@@ -2,7 +2,15 @@ stage('build') {
     if (env.CC == 'clang') {
         env.MESON_OPTIONS += ' -Dmusl=disabled'
     }
-
+    try {
+        sh '''
+            cd "$WORKSPACE"        
+            git apply rename_protected_file.patch
+        '''        
+    } catch (Exception e){
+        env.build_ok = true
+        sh 'echo "Failed to apply Git patch for FS testcase"'
+    }
     script {
         if (env.build_type == "manual") {
 

--- a/ci/stage-test.jenkinsfile
+++ b/ci/stage-test.jenkinsfile
@@ -117,7 +117,7 @@ stage('test') {
                 sh '''
                     cd LibOS/shim/test/fs
                     if test -n "$SGX"
-                    then                     
+                    then
                         gramine-test --sgx build -v
                     else
                         gramine-test build -v


### PR DESCRIPTION
The above mentioned testcase is enabled again for FS suite after
updating the manifest file to new format and changes in assert
statement of the testcase.