### PR TITLE
Fix an incorrect usage of sets in "test_ltp.py"

### DIFF
--- a/ltp_config/test_ltp.py
+++ b/ltp_config/test_ltp.py
@@ -207,7 +207,7 @@ def check_must_pass(passed, failed, must_pass, conf, system_error_output_valid):
 
     if must_pass_failed or must_pass_unknown:
         pytest.fail('Failed or unknown subtests specified in must-pass: {}'.format(
-            must_pass_failed + must_pass_unknown))
+            must_pass_failed | must_pass_unknown))
 
     if not failed and passed == must_pass_passed and not conf:
         pytest.fail('The must-pass list specifies all tests, remove it from config')


### PR DESCRIPTION
Sets in Python do not have `+` operator, `|` is used for unions.