### PR TITLE
Enabling Busybox example and skipping examples for OOT

### DIFF
--- a/ci/stage-test-direct.jenkinsfile
+++ b/ci/stage-test-direct.jenkinsfile
@@ -74,7 +74,8 @@ stage('test-direct') {
         sh 'echo "Bash Example Test Failed"'
     }
 
-    if (env.os_release_id == "ubuntu") {
+    if (env.os_release_id == "ubuntu" && (Float.parseFloat(env.os_version) < 21)) 
+    {
         try {
             timeout(time: 10, unit: 'MINUTES') {
                 sh '''
@@ -174,6 +175,19 @@ stage('test-direct') {
     } catch (Exception e){
         env.build_ok = false
         sh 'echo "SQLite Example Test Failed"'
+    }
+    
+    try{
+        timeout(time: 10, unit: 'MINUTES') {
+            sh '''
+                cd CI-Examples/busybox
+                make ${MAKEOPTS} all
+                make ${MAKEOPTS} check 2>&1 | tee result.txt
+            '''
+        }
+    } catch (Exception e){
+        env.build_ok = false
+        sh 'echo "Busybox Example Test Failed"'
     }
 
     if(env.no_cpu.toInteger() > 16) 

--- a/ci/stage-test-examples.jenkinsfile
+++ b/ci/stage-test-examples.jenkinsfile
@@ -28,7 +28,8 @@ stage('test-examples') {
         }
     }
 
-    if ((Float.parseFloat(env.os_version) < 21) && !((env.node_label == "graphene_dcap") && (env.SGX == '1'))) {
+    if ((Float.parseFloat(env.os_version) < 21) && !((env.node_label == "graphene_oot") && (env.SGX == '1')) && !((env.node_label == "graphene_dcap") && (env.SGX == '1')))
+    {
         try {
             timeout(time: 15, unit: 'MINUTES') {
                 sh '''
@@ -54,41 +55,72 @@ stage('test-examples') {
             sh 'echo "TensorFlow Example Test Failed"'
         }
     }
-
-    try {
-        timeout(time: 10, unit: 'MINUTES') {
-            sh '''
-                cd CI-Examples/curl
-                if [ "${os_release_id}" != 'ubuntu' ]
-                then
-                    sed -i '$ a loader.pal_internal_mem_size = "64M"' curl.manifest.template
-                fi
-                make ${MAKEOPTS} all
-                make ${MAKEOPTS} check > RESULT
-            '''
+    if (!((env.node_label == "graphene_oot") && (env.SGX == '1')))
+    {
+        try {
+            timeout(time: 10, unit: 'MINUTES') {
+                sh '''
+                    cd CI-Examples/curl
+                    if [ "${os_release_id}" != 'ubuntu' ]
+                    then
+                        sed -i '$ a loader.pal_internal_mem_size = "64M"' curl.manifest.template
+                    fi
+                    make ${MAKEOPTS} all
+                    make ${MAKEOPTS} check > RESULT
+                '''
+            }
+        } catch (Exception e){
+            env.build_ok = false
+            sh 'echo "Curl Example Test Failed"'
         }
-    } catch (Exception e){
-        env.build_ok = false
-        sh 'echo "Curl Example Test Failed"'
-    }
 
-    try {
-        timeout(time: 5, unit: 'MINUTES') {
-            sh '''
-                cd CI-Examples/nodejs
-                if [ "${os_release_id}" != 'ubuntu' ]
-                then
-                    sed -i '$ a loader.pal_internal_mem_size = "64M"' nodejs.manifest.template
-                    sed -i "s/{{ nodejs_dir }}\\/nodejs/{{ nodejs_dir }}\\/node/g" nodejs.manifest.template
-                fi
-                make ${MAKEOPTS} all
-                make ${MAKEOPTS} check > RESULT
-            '''
+        try {
+            timeout(time: 5, unit: 'MINUTES') {
+                sh '''
+                    cd CI-Examples/nodejs
+                    if [ "${os_release_id}" != 'ubuntu' ]
+                    then
+                        sed -i '$ a loader.pal_internal_mem_size = "64M"' nodejs.manifest.template
+                        sed -i "s/{{ nodejs_dir }}\\/nodejs/{{ nodejs_dir }}\\/node/g" nodejs.manifest.template
+                    fi
+                    make ${MAKEOPTS} all
+                    make ${MAKEOPTS} check > RESULT
+                '''
+            }
+        } catch (Exception e){
+            env.build_ok = false
+            sh 'echo "Nodejs Example Test Failed"'
         }
-    } catch (Exception e){
-        env.build_ok = false
-        sh 'echo "Nodejs Example Test Failed"'
-    }
+
+        try {
+            timeout(time: 10, unit: 'MINUTES') {
+                sh '''
+                    cd CI-Examples/r
+                    if [ "${os_release_id}" != 'ubuntu' ]
+                    then
+                        export R_HOME=/usr/lib64/R
+                        sed -i '$ a loader.pal_internal_mem_size = "128M"' R.manifest.template
+                        sed -i \'/^sgx.trusted_files = \\[.*/a "file:/usr/bin/which",\' R.manifest.template
+                        sed -i \'/^sgx.trusted_files = \\[.*/a "file:/usr/bin/uname",\' R.manifest.template
+                        sed -i \'/^sgx.trusted_files = \\[.*/a "file:/usr/bin/sh",\' R.manifest.template
+                        sed -i \'/^sgx.trusted_files = \\[.*/a "file:/usr/bin/rm",\' R.manifest.template
+                        sed -i 's/sgx.enclave_size = "1G"/sgx.enclave_size = "2G"/' R.manifest.template
+                    fi
+                    if [ "${os_release_id}" = 'centos' ]
+                    then
+                        sed -i \'/^sgx.trusted_files = \\[.*/a "file:/usr/bin/coreutils",\' R.manifest.template
+                        sed -i \'/^sgx.trusted_files = \\[.*/a "file:/usr/lib64/libcap.so.2",\' R.manifest.template
+                    fi
+                    make ${MAKEOPTS} all
+                    gramine-${MODE} ./R --slave --vanilla -f scripts/sample.r > RESULT_1
+                    gramine-${MODE} ./R --slave --vanilla -f scripts/R-benchmark-25.R > RESULT_2
+                '''
+            }
+        } catch (Exception e){
+            env.build_ok = false
+            sh 'echo "R Example Test Failed"'
+        }
+    }    
 
     if (!((env.no_cpu.toInteger() < 16) && (env.SGX == '1')))
     {
@@ -117,35 +149,6 @@ stage('test-examples') {
             env.build_ok = false
             sh 'echo "Pytorch Example Test Failed"'
         }
-    }
-
-    try {
-        timeout(time: 10, unit: 'MINUTES') {
-            sh '''
-                cd CI-Examples/r
-                if [ "${os_release_id}" != 'ubuntu' ]
-                then
-                    export R_HOME=/usr/lib64/R
-                    sed -i '$ a loader.pal_internal_mem_size = "128M"' R.manifest.template
-                    sed -i \'/^sgx.trusted_files = \\[.*/a "file:/usr/bin/which",\' R.manifest.template
-                    sed -i \'/^sgx.trusted_files = \\[.*/a "file:/usr/bin/uname",\' R.manifest.template
-                    sed -i \'/^sgx.trusted_files = \\[.*/a "file:/usr/bin/sh",\' R.manifest.template
-                    sed -i \'/^sgx.trusted_files = \\[.*/a "file:/usr/bin/rm",\' R.manifest.template
-                    sed -i 's/sgx.enclave_size = "1G"/sgx.enclave_size = "2G"/' R.manifest.template
-                fi
-                if [ "${os_release_id}" = 'centos' ]
-                then
-                    sed -i \'/^sgx.trusted_files = \\[.*/a "file:/usr/bin/coreutils",\' R.manifest.template
-                    sed -i \'/^sgx.trusted_files = \\[.*/a "file:/usr/lib64/libcap.so.2",\' R.manifest.template
-                fi
-                make ${MAKEOPTS} all
-                gramine-${MODE} ./R --slave --vanilla -f scripts/sample.r > RESULT_1
-                gramine-${MODE} ./R --slave --vanilla -f scripts/R-benchmark-25.R > RESULT_2
-            '''
-        }
-    } catch (Exception e){
-        env.build_ok = false
-        sh 'echo "R Example Test Failed"'
     }
 
     if (!((env.no_cpu.toInteger() < 16) && (env.SGX == '1'))) {
@@ -192,7 +195,8 @@ stage('test-examples') {
         sh 'echo "Rust example Test Failed"'
     }
 
-    if (env.os_release_id == "ubuntu") {
+    if (env.os_release_id == "ubuntu" && (!((env.node_label == "graphene_oot") && (env.SGX == '1'))))
+    {
         try {
             timeout(time: 10, unit: 'MINUTES') {
                 sh '''

--- a/ci/stage-test-sgx.jenkinsfile
+++ b/ci/stage-test-sgx.jenkinsfile
@@ -63,7 +63,8 @@ stage('test-sgx') {
         sh 'echo "Bash Example Test Failed"'
     }
  
-    if (env.os_release_id == "ubuntu") {  
+    if (env.os_release_id == "ubuntu" && (Float.parseFloat(env.os_version) < 21)) 
+    {  
         try {
             timeout(time: 15, unit: 'MINUTES') {
                 sh '''
@@ -241,6 +242,23 @@ stage('test-sgx') {
             fi
         '''
     }*/
+    try{
+        timeout(time: 10, unit: 'MINUTES') {
+            sh '''
+                cd CI-Examples/busybox
+                if [ "${os_release_id}" != 'ubuntu' ]
+                then
+                    sed -i '$ a loader.pal_internal_mem_size = "64M"' busybox.manifest.template
+                    sed -i '$ a sgx.nonpie_binary = true' busybox.manifest.template
+                fi                
+                make ${MAKEOPTS} all
+                make ${MAKEOPTS} SGX=1 check 2>&1 | tee result.txt
+            '''
+        }
+    } catch (Exception e){
+        env.build_ok = false
+        sh 'echo "Busybox Example Test Failed"'
+    }
 
     if(env.no_cpu.toInteger() > 16) 
     { 

--- a/test_workloads.py
+++ b/test_workloads.py
@@ -33,7 +33,8 @@ class Test_Workload_Results():
         assert("Success 4/4" in python_contents)
 
     @pytest.mark.examples
-    @pytest.mark.skipif(os_release_id != "ubuntu",
+    @pytest.mark.skipif((os_release_id != "ubuntu" or
+                    float(os_version) >= 21),
                     reason="Memcached libraries not available for CENT/RHEL")
     def test_memcached_workload(self):
         memcached_result_file = open("CI-Examples/memcached/OUTPUT.txt", "r")
@@ -78,6 +79,12 @@ class Test_Workload_Results():
                 and ("row 3" in sqlite_contents) \
                 and ("row 2" in sqlite_contents) \
                 and ("row 1" in sqlite_contents))
+    
+    @pytest.mark.examples
+    def test_busybox_workload(self):
+        busybox_result_file = open("CI-Examples/busybox/result.txt", "r")
+        busybox_contents = busybox_result_file.read()
+        assert("Success 1/1" in busybox_contents)
 
     @pytest.mark.examples
     @pytest.mark.skipif((int(no_cores) < 16),
@@ -113,6 +120,7 @@ class Test_Workload_Results():
 
     @pytest.mark.examples
     @pytest.mark.skipif(float(os_version) >= 21 or
+                ((node_label == 'graphene_oot') and sgx_mode == '1') or
                 ((node_label == 'graphene_dcap') and sgx_mode == '1'),
                     reason="Bazel Build fails for Ubuntu 21 and Graphene DCAP")
     def test_tensorflow_workload(self):
@@ -126,12 +134,16 @@ class Test_Workload_Results():
             and (re.search("\d+: 458 bow tie", tensorflow_contents)))
 
     @pytest.mark.examples
+    @pytest.mark.skipif(((node_label == 'graphene_oot') and sgx_mode == '1'),
+                    reason="Curl skipped for OOT with SGX.")
     def test_curl_workload(self):
         curl_result_file = open("CI-Examples/curl/RESULT", "r")
         curl_contents = curl_result_file.read()
         assert("Success 1/1" in curl_contents)
 
     @pytest.mark.examples
+    @pytest.mark.skipif(((node_label == 'graphene_oot') and sgx_mode == '1'),
+                    reason="NodeJS skipped for OOT with SGX.")
     def test_nodejs_workload(self):
         nodejs_result_file = open("CI-Examples/nodejs/RESULT", "r")
         nodejs_contents = nodejs_result_file.read()
@@ -150,6 +162,8 @@ class Test_Workload_Results():
             and ("Ibizan hound, Ibizan Podenco" in pytorch_contents))
 
     @pytest.mark.examples
+    @pytest.mark.skipif(((node_label == 'graphene_oot') and sgx_mode == '1'),
+                    reason="R skipped for OOT with SGX.")
     def test_r_workload(self):
         r1_result_file = open("CI-Examples/r/RESULT_1", "r")
         r1_contents = r1_result_file.read()
@@ -166,7 +180,8 @@ class Test_Workload_Results():
             and ("--- End of test ---" in r2_contents))
 
     @pytest.mark.examples
-    @pytest.mark.skipif((os_release_id != "ubuntu"),
+    @pytest.mark.skipif((os_release_id != "ubuntu") or
+            ((node_label == 'graphene_oot') and sgx_mode == '1'),
                     reason="GCC enabled only for Ubuntu configurations.")
     def test_gcc_workload(self):
         gcc_result_file = open("CI-Examples/gcc/OUTPUT", "r")


### PR DESCRIPTION
The busybox example is enabled for all the configurations.
The failing examples due to AESM error are skipped for OOT.
Memcached is skipped for Ubuntu 21.10.