### PR TITLE
Updating the parser for Bash example

### DIFF
--- a/ci/linux-direct-centos8-docker-gcc-release.jenkinsfile
+++ b/ci/linux-direct-centos8-docker-gcc-release.jenkinsfile
@@ -33,9 +33,6 @@ node(node_label) {
             sh 'sed -i \'s/.release  = "3.10.0"/.release  = "5.10.0"/\' \
                 $WORKSPACE/LibOS/shim/src/sys/shim_uname.c'
 
-            sh 'sed -i \'s/bash -c "ls"/bash -c "free"/g\' CI-Examples/bash/Makefile'
-            sh 'sed -i \'s/readlink/total/g\' test_workloads.py'
-            
             load '../ci/config-docker.jenkinsfile'
             docker.build(
                 "local:${env.BUILD_TAG}",

--- a/ci/linux-sgx-centos8-docker-gcc-release.jenkinsfile
+++ b/ci/linux-sgx-centos8-docker-gcc-release.jenkinsfile
@@ -34,10 +34,7 @@ node (node_label) {
             sh 'sed -i -e \'s/dent != g_dentry_root && dent->state & DENTRY_VALID/0/\' \
                 $WORKSPACE/LibOS/shim/src/fs/shim_fs.c'
             sh 'sed -i \'s/.release  = "3.10.0"/.release  = "5.10.0"/\' \
-                $WORKSPACE/LibOS/shim/src/sys/shim_uname.c'
-                
-            sh 'sed -i \'s/bash -c "ls"/bash -c "free"/g\' CI-Examples/bash/Makefile'
-            sh 'sed -i \'s/readlink/total/g\' test_workloads.py'
+                $WORKSPACE/LibOS/shim/src/sys/shim_uname.c'          
 
             load '../ci/config-docker.jenkinsfile'
             docker.build(

--- a/ci/stage-test-direct.jenkinsfile
+++ b/ci/stage-test-direct.jenkinsfile
@@ -65,8 +65,12 @@ stage('test-direct') {
             sh '''
                 cd CI-Examples/bash
                 sed -i '/@rm OUTPUT/d' Makefile
+                if [ "${os_release_id}" = "centos" ]
+                then
+                    sed -i "s/bin\\/readlink/bin\\/coreutils/" Makefile
+                fi                
                 make ${MAKEOPTS} all
-                make ${MAKEOPTS} regression
+                make ${MAKEOPTS} regression 2>&1 | tee result.txt
             '''
         }
     } catch (Exception e){

--- a/ci/stage-test-sgx.jenkinsfile
+++ b/ci/stage-test-sgx.jenkinsfile
@@ -50,12 +50,17 @@ stage('test-sgx') {
             sh '''
                 cd CI-Examples/bash
                 sed -i '/@rm OUTPUT/d' Makefile
+                if [ "${os_release_id}" = "centos" ]
+                then
+                    sed -i "s/bin\\/readlink/bin\\/coreutils/" Makefile
+                    sed -i 's/sgx.enclave_size = "256M"/sgx.enclave_size = "512M"/g' manifest.template
+                fi
                 if [ "${os_release_id}" != 'ubuntu' ]
                 then
                     sed -i '$ a loader.pal_internal_mem_size = "128M"' manifest.template 
-                fi                    
+                fi
                 make ${MAKEOPTS} all
-                make ${MAKEOPTS} SGX=1 regression
+                make ${MAKEOPTS} SGX=1 regression 2>&1 | tee result.txt
             '''
         }
     } catch (Exception e){

--- a/ltp_config/ltp-sgx_tests.cfg
+++ b/ltp_config/ltp-sgx_tests.cfg
@@ -78,7 +78,7 @@ timeout = 60
 skip = yes
 
 [getpid01]
-timeout = 90
+timeout = 150
 
 [getsid01]
 skip = yes

--- a/test_workloads.py
+++ b/test_workloads.py
@@ -17,9 +17,15 @@ class Test_Workload_Results():
     @pytest.mark.examples
     @pytest.mark.debian_verification
     def test_bash_workload(self):
-        bash_result_file = open("CI-Examples/bash/OUTPUT", "r")
+        bash_result_file = open("CI-Examples/bash/result.txt", "r")
         bash_contents = bash_result_file.read()
-        assert("readlink" in bash_contents)
+        assert("Success 1/7" in bash_contents)
+        assert("Success 2/7" in bash_contents)
+        assert("Success 3/7" in bash_contents)
+        assert("Success 4/7" in bash_contents)
+        assert("Success 5/7" in bash_contents)
+        assert("Success 6/7" in bash_contents)
+        assert("Success 7/7" in bash_contents)
 
     @pytest.mark.examples
     @pytest.mark.skipif((os_release_id != "ubuntu" and sgx_mode == '1'),


### PR DESCRIPTION
The parser for Bash example is updated to check for command "ls",
which was not supported on CentOS/RHEL earlier.
Also, timeout for getpid01 is increased.