### PR TITLE
Run timeout-prone tests with unbufferred output for LTP

### DIFF
--- a/ci/stage-test-direct.jenkinsfile
+++ b/ci/stage-test-direct.jenkinsfile
@@ -26,6 +26,7 @@ stage('test-direct') {
             // separately
             sh '''
                 cd LibOS/shim/test/ltp
+                export GRAMINE_LTP_LIVE_OUTPUT=fcntl14,fdatasync01
                 python3 -m pytest -v  --junit-xml=ltp.xml
             '''            
             /*

--- a/ci/stage-test-sgx.jenkinsfile
+++ b/ci/stage-test-sgx.jenkinsfile
@@ -26,6 +26,7 @@ stage('test-sgx') {
             // separately
             sh '''
                 cd LibOS/shim/test/ltp
+                export GRAMINE_LTP_LIVE_OUTPUT=fcntl14,fdatasync01
                 python3 -m pytest -v  --junit-xml=ltp-sgx.xml
             '''                
             /*

--- a/ltp_config/test_ltp.py
+++ b/ltp_config/test_ltp.py
@@ -246,7 +246,7 @@ def check_system_error_output_valid(_stderr):
             return False
     return ret_code
 
-def test_ltp(cmd, section):
+def test_ltp(cmd, section, capsys):
     must_pass = section.getintset('must-pass')
     if sgx_mode == '1':
         binary_dir_ltp = "install-sgx/testcases/bin"
@@ -262,7 +262,12 @@ def test_ltp(cmd, section):
     logging.info('command: %s', full_cmd)
     logging.info('must_pass: %s', list(must_pass) if must_pass else 'all')
 
-    returncode, stdout, _stderr = run_command(full_cmd, timeout=timeout, can_fail=True)
+    live_output = os.getenv('GRAMINE_LTP_LIVE_OUTPUT') or ''
+    if section.name in live_output.split(','):
+        with capsys.disabled():
+            returncode, stdout, _stderr = run_command(full_cmd, timeout=timeout, can_fail=True)
+    else:
+        returncode, stdout, _stderr = run_command(full_cmd, timeout=timeout, can_fail=True)
 
     # Parse output regardless of whether `must_pass` is specified: unfortunately some tests
     # do not exit with non-zero code when failing, because they rely on `MAP_SHARED` (which


### PR DESCRIPTION
This will make CI timestamp each output line of the LTP binary, making
it possible to check whether these are hangs, or just a case of the
tests executing slow enough to time out.