### PR TITLE
Increasing timeout for R

### DIFF
--- a/ci/lib/stage-test-examples.jenkinsfile
+++ b/ci/lib/stage-test-examples.jenkinsfile
@@ -93,7 +93,7 @@ stage('test-examples') {
         }
 
         try {
-            timeout(time: 10, unit: 'MINUTES') {
+            timeout(time: 20, unit: 'MINUTES') {
                 sh '''
                     cd CI-Examples/r
                     if [ "${os_release_id}" != 'ubuntu' ]


### PR DESCRIPTION
The timeout for R is increased following recent failures on some
client machines.