### PR TITLE
Disable RA (Remote Attestation) for python example

### DIFF
--- a/ci/lib/stage-test-sgx.jenkinsfile
+++ b/ci/lib/stage-test-sgx.jenkinsfile
@@ -92,7 +92,7 @@ stage('test-sgx') {
             timeout(time: 5, unit: 'MINUTES') {
                 sh '''
                     cd CI-Examples/python
-                    make ${MAKEOPTS} DEBUG=1 RA_TYPE=epid RA_CLIENT_SPID=${ra_client_spid}
+                    make ${MAKEOPTS} DEBUG=1
                     make ${MAKEOPTS} SGX=1 check
                 '''
             }


### PR DESCRIPTION
As the CI machines are not enabled with RA, python test cases are
failing for SGX.
In this commit, we are building python without RA flag.