### PR TITLE
Update installation of python3-pyelftools for CentOS

### DIFF
--- a/gsc/templates/centos/Dockerfile.build.template
+++ b/gsc/templates/centos/Dockerfile.build.template
@@ -18,9 +18,11 @@ RUN dnf update -y \
         python3 \
         python3-pip \
         python3-protobuf \
-        python3-pyelftools \
         python3-cryptography \
     && /usr/bin/python3 -B -m pip install --proxy=http://proxy-dmz.intel.com:911 click jinja2 protobuf 'toml>=0.10'
+
+# Install pyelftools after the installation of epel-release as it is provided by the EPEL repo
+RUN dnf install -y python3-pyelftools
 
 {% if debug %}
 RUN dnf install -y \


### PR DESCRIPTION
This package is provided by `epel.repo` and hence installed after
the installation of `epel-release`.
http://ba5sapp0350:8080/view/Graphene/job/local_ci_graphene_gsc_centos/36/console