### PR TITLE
Increase wait time for server to launch successfully

### DIFF
--- a/ci/lib/stage-test-sgx.jenkinsfile
+++ b/ci/lib/stage-test-sgx.jenkinsfile
@@ -172,7 +172,7 @@ stage('test-sgx') {
                 fi                
                 make ${MAKEOPTS} all
                 make ${MAKEOPTS} SGX=1 start-gramine-server &
-                ../../scripts/wait_for_server 60 127.0.0.1 8002
+                ../../scripts/wait_for_server 120 127.0.0.1 8002
                 LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh http://127.0.0.1:8002
             '''
         }


### PR DESCRIPTION
The server does not succesfully launch for centos and rhel, increasing the timeout to launch successfully so that workload can execute successfully

http://ba5sapp0350:8080/job/local_ci_graphene_sgx_centos_5.18/469/console