### PR TITLE
Remove loader.argv0_override manifest option.

### DIFF
--- a/ci/lib/stage-test-examples.jenkinsfile
+++ b/ci/lib/stage-test-examples.jenkinsfile
@@ -139,7 +139,7 @@ try {
                     fi
                     if [ "${no_cpu}" -gt 100 ] && ([ "${base_os}" = 'ubuntu18.04' ] || [ "${os_release_id}" == 'centos' ] || [ "${os_release_id}" == 'rhel' ])
                     then
-                        sed -i 's/sgx.enclave_size = "2G"/sgx.enclave_size = "4G"/g' pytorch.manifest.template
+                        sed -i 's/sgx.enclave_size = "2G"/sgx.enclave_size = "8G"/g' pytorch.manifest.template
                         sed -i 's/sgx.thread_num = 16/sgx.thread_num = 32/g' pytorch.manifest.template
                     fi
                     python3 download-pretrained-model.py

--- a/go_helloworld/helloworld.manifest.template
+++ b/go_helloworld/helloworld.manifest.template
@@ -1,9 +1,8 @@
 # Hello World manifest file example
 
 loader.entrypoint = "file:{{ gramine.libos }}"
-libos.entrypoint = "helloworld"
+libos.entrypoint = "/helloworld"
 loader.log_level = "{{ log_level }}"
-loader.argv0_override = "helloworld"
 loader.env.GOPATH = "/usr/lib/go-1.10:/usr/lib/go"
 loader.env.PATH = "/usr/lib/go-1.10/bin:/usr/lib/go/bin"
 
@@ -11,6 +10,7 @@ loader.env.LD_LIBRARY_PATH = "/lib"
 
 fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "/helloworld", uri = "file:helloworld" },
 ]
 
 sgx.debug = true

--- a/perf_benchmarking/redis/redis_server_scripts/redis-server.manifest.template
+++ b/perf_benchmarking/redis/redis_server_scripts/redis-server.manifest.template
@@ -7,7 +7,7 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 
 # Entrypoint binary which Gramine invokes.
-libos.entrypoint = "redis-server"
+libos.entrypoint = "/redis-server"
 
 # Verbosity of Gramine debug log (none/error/warning/debug/trace/all). Note
 # that GRAMINE_LOG_LEVEL macro is expanded in the Makefile as part of the
@@ -45,27 +45,24 @@ sys.enable_sigterm_injection = true
 # - In-Gramine visible path names may be arbitrary but we reuse host-OS URIs
 #   for simplicity (except for the first 'lib' case).
 
-# Mount host-OS directory to Gramine glibc/runtime libraries (in 'uri') into
-# in-Gramine visible directory /lib (in 'path').
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
+fs.mounts = [
+  # Mount host-OS directory to Gramine glibc/runtime libraries (in 'uri') into
+  # in-Gramine visible directory /lib (in 'path').
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
 
-# Mount host-OS directory to Name Service Switch (NSS) libraries (in 'uri')
-# into in-Gramine visible directory /lib/x86_64-linux-gnu (in 'path').
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "{{ arch_libdir }}"
-fs.mount.lib2.uri = "file:{{ arch_libdir }}"
+  # Mount host-OS directory to Name Service Switch (NSS) libraries (in 'uri')
+  # into in-Gramine visible directory /lib/x86_64-linux-gnu (in 'path').
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+  { path = "/usr/{{ arch_libdir }}", uri = "file:/usr/{{ arch_libdir }}" },
 
-fs.mount.lib3.type = "chroot"
-fs.mount.lib3.path = "/usr/{{ arch_libdir }}"
-fs.mount.lib3.uri = "file:/usr/{{ arch_libdir }}"
+  # Mount host-OS directory to NSS files required by Glibc + NSS libs (in 'uri')
+  # into in-Gramine visible directory /etc (in 'path').
+  { path = "/etc", uri = "file:/etc" },
 
-# Mount host-OS directory to NSS files required by Glibc + NSS libs (in 'uri')
-# into in-Gramine visible directory /etc (in 'path').
-fs.mount.etc.type = "chroot"
-fs.mount.etc.path = "/etc"
-fs.mount.etc.uri = "file:/etc"
+  # Mount redis-server executable (located in the current directory) under the
+  # in-Gramine visible root directory.
+  { path = "/redis-server", uri = "file:redis-server" },
+]
 
 ############################### SGX: GENERAL ##################################
 


### PR DESCRIPTION
Removed loader.argv0_override manifest option and worked on entrypoint changes.
Increased enclave size for pytorch.

http://ba5sapp0350:8080/view/Graphene/job/local_ci_graphene_sgx_18.04_5.14/615/testReport/test_workloads/Test_Workload_Results/
