### PR TITLE
Update manifest files for tf perf

### DIFF
--- a/perf_benchmarking/bert/python.manifest.template
+++ b/perf_benchmarking/bert/python.manifest.template
@@ -11,45 +11,18 @@ loader.env.LD_LIBRARY_PATH = "{{ python.stdlib }}/lib:/lib:{{ arch_libdir }}:/us
 
 loader.pal_internal_mem_size = "512M"
 
-fs.mount.usr_local.type = "chroot"
-fs.mount.usr_local.path = "/usr/local"
-fs.mount.usr_local.uri = "file:/usr/local"
-
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
-
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "{{ arch_libdir }}"
-fs.mount.lib2.uri = "file:{{ arch_libdir }}"
-
-fs.mount.usr.type = "chroot"
-fs.mount.usr.path = "/usr"
-fs.mount.usr.uri = "file:/usr"
-
-fs.mount.pyhome.type = "chroot"
-fs.mount.pyhome.path = "{{ python.stdlib }}"
-fs.mount.pyhome.uri = "file:{{ python.stdlib }}"
-
-fs.mount.pydisthome.type = "chroot"
-fs.mount.pydisthome.path = "{{ python.distlib }}"
-fs.mount.pydisthome.uri = "file:{{ python.distlib }}"
-
-fs.mount.pydisthome_1.type = "chroot"
-fs.mount.pydisthome_1.path = "/usr/local/lib/python3.6/dist-packages"
-fs.mount.pydisthome_1.uri = "file:/usr/local/lib/python3.6/dist-packages"
-
-fs.mount.pydistpath.type = "chroot"
-fs.mount.pydistpath.path = "{{ pythondistpath }}"
-fs.mount.pydistpath.uri = "file:{{ pythondistpath }}"
-
-fs.mount.tmp.type = "chroot"
-fs.mount.tmp.path = "/tmp"
-fs.mount.tmp.uri = "file:/tmp"
-
-fs.mount.etc.type = "chroot"
-fs.mount.etc.path = "/etc"
-fs.mount.etc.uri = "file:/etc"
+fs.mounts = [
+  { path = "/usr/local", uri = "file:/usr/local"},
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}"},
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}"},
+  { path = "/usr", uri = "file:/usr"},
+  { path = "{{ python.stdlib }}", uri = "file:{{ python.stdlib }}"},
+  { path = "{{ python.distlib }}", uri = "file:{{ python.distlib }}"},
+  { path = "/usr/local/lib/python3.6/dist-packages", uri = "file:/usr/local/lib/python3.6/dist-packages"},
+  { path = "{{ pythondistpath }}", uri = "file:{{ pythondistpath }}"},
+  { path = "/tmp", uri = "file:/tmp"},
+  { path = "/etc", uri = "file:/etc"},
+]
 
 sgx.enclave_size = "32G"
 sgx.thread_num = 256

--- a/perf_benchmarking/resnet/python.manifest.template
+++ b/perf_benchmarking/resnet/python.manifest.template
@@ -11,45 +11,18 @@ loader.env.LD_LIBRARY_PATH = "{{ python.stdlib }}/lib:/lib:{{ arch_libdir }}:/us
 
 loader.pal_internal_mem_size = "512M"
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
-
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "{{ arch_libdir }}"
-fs.mount.lib2.uri = "file:{{ arch_libdir }}"
-
-fs.mount.usr.type = "chroot"
-fs.mount.usr.path = "/usr"
-fs.mount.usr.uri = "file:/usr"
-
-fs.mount.bin.type = "chroot"
-fs.mount.bin.path = "/bin"
-fs.mount.bin.uri = "file:/bin"
-
-fs.mount.pyhome.type = "chroot"
-fs.mount.pyhome.path = "{{ python.stdlib }}"
-fs.mount.pyhome.uri = "file:{{ python.stdlib }}"
-
-fs.mount.pydisthome.type = "chroot"
-fs.mount.pydisthome.path = "{{ python.distlib }}"
-fs.mount.pydisthome.uri = "file:{{ python.distlib }}"
-
-fs.mount.pydisthome_1.type = "chroot"
-fs.mount.pydisthome_1.path = "/usr/local/lib/python3.6/dist-packages"
-fs.mount.pydisthome_1.uri = "file:/usr/local/lib/python3.6/dist-packages"
-
-fs.mount.pydistpath.type = "chroot"
-fs.mount.pydistpath.path = "{{ pythondistpath }}"
-fs.mount.pydistpath.uri = "file:{{ pythondistpath }}"
-
-fs.mount.tmp.type = "chroot"
-fs.mount.tmp.path = "/tmp"
-fs.mount.tmp.uri = "file:/tmp"
-
-fs.mount.etc.type = "chroot"
-fs.mount.etc.path = "/etc"
-fs.mount.etc.uri = "file:/etc"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}"},
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}"},
+  { path = "/usr", uri = "file:/usr"},
+  { path = "/bin", uri = "file:/bin"},
+  { path = "{{ python.stdlib }}", uri = "file:{{ python.stdlib }}"},
+  { path = "{{ python.distlib }}", uri = "file:{{ python.distlib }}"},
+  { path = "/usr/local/lib/python3.6/dist-packages", uri = "file:/usr/local/lib/python3.6/dist-packages"},
+  { path = "{{ pythondistpath }}", uri = "file:{{ pythondistpath }}"},
+  { path = "/tmp", uri = "file:/tmp"},
+  { path = "/etc", uri = "file:/etc"},
+]
 
 sgx.enclave_size = "32G"
 sgx.thread_num = 300


### PR DESCRIPTION
Updated the manifest files for bert and resnet to confirm to the new fs.mount format.
http://ba5sapp0350:8080/view/Graphene/job/local_ci_graphene_perf_resnet/167/console