### PR TITLE
manifest-option names are renamed  from sgx.thread_num to sgx.max_threads

### DIFF
--- a/Python/python.manifest.template
+++ b/Python/python.manifest.template
@@ -28,7 +28,7 @@ sys.enable_extra_runtime_domain_names_conf = true
 sgx.debug = true
 sgx.nonpie_binary = true
 sgx.enclave_size = "2G"
-sgx.thread_num = 64
+sgx.max_threads = 64
 
 sgx.remote_attestation = "{{ ra_type }}"
 sgx.ra_client_spid = "{{ ra_client_spid }}"

--- a/ci/lib/stage-test-sgx.jenkinsfile
+++ b/ci/lib/stage-test-sgx.jenkinsfile
@@ -75,7 +75,7 @@ stage('test-sgx') {
                 if [ "${base_os}" = 'ubuntu18.04' ] && [ "${no_cpu}" -gt 100 ]
                 then
                     sed -i 's/sgx.enclave_size = "2G"/sgx.enclave_size = "16G"/g' python.manifest.template
-                    sed -i 's/sgx.thread_num = 64/sgx.thread_num = 256/g' python.manifest.template
+                    sed -i 's/sgx.max_threads = 64/sgx.max_threads = 256/g' python.manifest.template
                 fi
                 make ${MAKEOPTS} DEBUG=1
                 make ${MAKEOPTS} SGX=1 check
@@ -158,7 +158,7 @@ stage('test-sgx') {
             if [ "${no_cpu}" -gt 16 ]
             then
                 sed -i 's/sgx.enclave_size = "2048M"/sgx.enclave_size = "4G"/g' blender.manifest.template
-                sed -i 's/sgx.thread_num = 64/sgx.thread_num = 256/g' blender.manifest.template
+                sed -i 's/sgx.max_threads = 64/sgx.max_threads = 256/g' blender.manifest.template
             fi
             make ${MAKEOPTS} all
             make ${MAKEOPTS} SGX=1 check	

--- a/ci/pkg_deb.jenkinsfile
+++ b/ci/pkg_deb.jenkinsfile
@@ -105,7 +105,7 @@ stage('test') {
             if [ "${no_cpu}" -gt 16 ]
             then
                 sed -i 's/sgx.enclave_size = "2048M"/sgx.enclave_size = "4G"/g' blender.manifest.template
-                sed -i 's/sgx.thread_num = 64/sgx.thread_num = 256/g' blender.manifest.template
+                sed -i 's/sgx.max_threads = 64/sgx.max_threads = 256/g' blender.manifest.template
             fi
             make ${MAKEOPTS} all
             make ${MAKEOPTS} SGX=1 check

--- a/go_helloworld/helloworld.manifest.template
+++ b/go_helloworld/helloworld.manifest.template
@@ -16,7 +16,7 @@ fs.mounts = [
 sgx.debug = true
 sgx.nonpie_binary = true
 sgx.enclave_size = "32G"
-sgx.thread_num = 256
+sgx.max_threads = 256
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/ltp_config/manifest.LTP
+++ b/ltp_config/manifest.LTP
@@ -74,4 +74,4 @@ sgx.allowed_files.glibclibnsscompat = "file:{{ gramine.runtimedir() }}/libnss_co
 sgx.allowed_files.libnsscompat = "file:{{ arch_libdir }}/libnss_compat.so.2"
 sgx.allowed_files.libnsssystemd = "file:{{ arch_libdir }}/libnss_systemd.so.2"
 
-sgx.thread_num = 13
+sgx.max_threads = 13

--- a/ltp_config/manifest_18_04.template
+++ b/ltp_config/manifest_18_04.template
@@ -25,7 +25,7 @@ sys.brk.max_size = "32M"
 sys.stack.size = "4M"
 sgx.nonpie_binary = true
 sgx.debug = true
-sgx.thread_num = 13
+sgx.max_threads = 13
 
 sgx.allowed_files = [
     "file:/tmp",

--- a/ltp_config/manifest_20_04_21_10.template
+++ b/ltp_config/manifest_20_04_21_10.template
@@ -25,7 +25,7 @@ sys.brk.max_size = "32M"
 sys.stack.size = "4M"
 sgx.nonpie_binary = true
 sgx.debug = true
-sgx.thread_num = 13
+sgx.max_threads = 13
 
 sgx.allowed_files = [
     "file:/tmp",

--- a/ltp_config/manifest_CentOS.template
+++ b/ltp_config/manifest_CentOS.template
@@ -25,7 +25,7 @@ sys.brk.max_size = "32M"
 sys.stack.size = "4M"
 sgx.nonpie_binary = true
 sgx.debug = true
-sgx.thread_num = 13
+sgx.max_threads = 13
 
 sgx.allowed_files = [
     "file:/tmp",

--- a/ltp_config/manifest_RHEL.template
+++ b/ltp_config/manifest_RHEL.template
@@ -25,7 +25,7 @@ sys.brk.max_size = "32M"
 sys.stack.size = "4M"
 sgx.nonpie_binary = true
 sgx.debug = true
-sgx.thread_num = 13
+sgx.max_threads = 13
 
 sgx.allowed_files = [
     "file:/tmp",

--- a/perf_benchmarking/bert/python.manifest.template
+++ b/perf_benchmarking/bert/python.manifest.template
@@ -23,7 +23,7 @@ fs.mounts = [
 ]
 
 sgx.enclave_size = "32G"
-sgx.thread_num = 256
+sgx.max_threads = 256
 sgx.preheat_enclave = true
 sgx.nonpie_binary = true
 

--- a/perf_benchmarking/redis/redis_server_scripts/redis-server.manifest.template
+++ b/perf_benchmarking/redis/redis_server_scripts/redis-server.manifest.template
@@ -86,7 +86,7 @@ sgx.enclave_size = "4G"
 # and one for asynchronous events/alarms. Redis is technically single-threaded
 # but spawns couple additional threads to do background bookkeeping. Therefore,
 # specifying '8' allows to run a maximum of 6 Redis threads which is enough.
-sgx.thread_num = 8
+sgx.max_threads = 8
 
 # Redis executable is typically a PIE (Position Independent Executable) on most
 # modern OS distros (e.g., Ubuntu 18.04). However, on some OS distros (notably,

--- a/perf_benchmarking/redis/redis_server_scripts/redis-server.manifest.template.exitless
+++ b/perf_benchmarking/redis/redis_server_scripts/redis-server.manifest.template.exitless
@@ -89,7 +89,7 @@ sgx.enclave_size = "4G"
 # and one for asynchronous events/alarms. Redis is technically single-threaded
 # but spawns couple additional threads to do background bookkeeping. Therefore,
 # specifying '8' allows to run a maximum of 6 Redis threads which is enough.
-sgx.thread_num = 8
+sgx.max_threads = 8
 sgx.rpc_thread_num = 8
 # Redis executable is typically a PIE (Position Independent Executable) on most
 # modern OS distros (e.g., Ubuntu 18.04). However, on some OS distros (notably,

--- a/perf_benchmarking/resnet/python.manifest.template
+++ b/perf_benchmarking/resnet/python.manifest.template
@@ -23,7 +23,7 @@ fs.mounts = [
 ]
 
 sgx.enclave_size = "32G"
-sgx.thread_num = 300
+sgx.max_threads = 300
 sgx.preheat_enclave = true
 sgx.nonpie_binary = true
 

--- a/stress-ng/stress-ng.manifest.template
+++ b/stress-ng/stress-ng.manifest.template
@@ -4,7 +4,7 @@ libos.entrypoint = "/usr/bin/stress-ng"
 loader.log_level = "error"
 sys.stack.size = "8M"
 sgx.enclave_size = "4G"
-sgx.thread_num = 512
+sgx.max_threads = 512
 
 sgx.nonpie_binary = true
 loader.insecure__use_cmdline_argv = true


### PR DESCRIPTION
[local_ci_graphene_sgx_18.04_5.18] http://ba5sapp0350:8080/view/Old%20Graphene%20Jobs/job/sumedha_graphene_sgx_job/42/consoleFull
[local_ci_graphene_sgx_rhel_client]  http://ba5sapp0350:8080/view/Old%20Graphene%20Jobs/job/sumedha_rhel/2/
[local_ci_graphene_sgx_centos_5.14]  http://ba5sapp0350:8080/view/Old%20Graphene%20Jobs/job/sumedha_centos/1/