### PR TITLE
Update Gramine-Dcap build logic. Dcap can be built with in-kernel headers

### DIFF
--- a/ci/config/config-docker.jenkinsfile
+++ b/ci/config/config-docker.jenkinsfile
@@ -4,6 +4,7 @@ env.PATH = env.PREFIX + '/bin:' + env.PATH
 
 // don't mess with PATH before reading this: https://issues.jenkins.io/browse/JENKINS-49076
 env.DOCKER_ARGS_COMMON = """
+    --net=host
     --device=/dev/kmsg:/dev/kmsg
     --device=/dev/cpu_dma_latency:/dev/cpu_dma_latency
     --env=PATH=${env.PREFIX}/bin:${env.PATH}
@@ -32,9 +33,7 @@ if (fileExists('/dev/sgx_enclave')) {
 if (fileExists('/dev/isgx')) {
     env.DOCKER_ARGS_SGX += ' --device=/dev/isgx:/dev/isgx'
 }
-if (fileExists('/dev/gsgx')) {
-    env.DOCKER_ARGS_SGX += ' --device=/dev/gsgx:/dev/gsgx'
-}
+
 if (fileExists('/var/run/aesmd/aesm.socket')) {
     env.DOCKER_ARGS_SGX += ' --volume=/var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket'
 }

--- a/ci/lib/stage-build-sgx.jenkinsfile
+++ b/ci/lib/stage-build-sgx.jenkinsfile
@@ -24,7 +24,7 @@ stage('build') {
 
                 '''
 
-                 try {
+                try {
                     sh '''
                     cd "$WORKSPACE"
                     meson setup build \
@@ -45,13 +45,8 @@ stage('build') {
                     archiveArtifacts 'ninja_build_log.txt'
                     archiveArtifacts 'ninja_install_log.txt'                    
                 }
-
             } else if (env.node_label == "graphene_dcap") {
                 sh '''
-                    cd /opt/intel
-                    git clone https://github.com/intel/SGXDataCenterAttestationPrimitives.git
-                    cd SGXDataCenterAttestationPrimitives
-                    git checkout DCAP_1.6
                     curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
                     echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
                     sudo apt-get update
@@ -60,25 +55,25 @@ stage('build') {
 
                 try {
                     sh '''
-                    cd "$WORKSPACE"
-                    meson setup build \
-                        --werror \
-                        --prefix="$PREFIX" \
-                        --buildtype="$BUILDTYPE" \
-                        -Ddirect=disabled \
-                        -Dsgx=enabled \
-                        -Dtests=enabled \
-                        -Dsgx_driver=dcap1.6 \
-                        -Ddcap=enabled \
-                        $MESON_OPTIONS > meson_cmd_output.txt
-                    ninja -vC build > ninja_build_log.txt
-                    ninja -vC build install > ninja_install_log.txt
-                    gramine-sgx-gen-private-key
+                        cd "$WORKSPACE"
+                        sed -i "/uname/ a '/usr/src/linux-headers-@0@/arch/x86/include/uapi'.format(run_command('uname', '-r').stdout().split('-generic')[0].strip())," meson.build
+                        meson setup build \
+                            --werror \
+                            --prefix="$PREFIX" \
+                            --buildtype="$BUILDTYPE" \
+                            -Ddirect=disabled \
+                            -Dtests=enabled \
+                            -Dsgx=enabled \
+                            -Ddcap=enabled \
+                            $MESON_OPTIONS > meson_cmd_output.txt
+                        ninja -vC build > ninja_build_log.txt
+                        ninja -vC build install > ninja_install_log.txt
+                        gramine-sgx-gen-private-key
                     '''
                 } finally {
                     archiveArtifacts 'build/meson-logs/**/*'
                     archiveArtifacts 'ninja_build_log.txt'
-                    archiveArtifacts 'ninja_install_log.txt'                       
+                    archiveArtifacts 'ninja_install_log.txt'
                 }
 
             } else {


### PR DESCRIPTION
http://ba5sapp0350:8080/view/Graphene/job/local_ci_graphene_sgx_dcap/498/console