### PR TITLE
Increased enclave for Tensorflow-lite

### DIFF
--- a/ci/lib/stage-test-examples.jenkinsfile
+++ b/ci/lib/stage-test-examples.jenkinsfile
@@ -33,6 +33,7 @@ stage('test-examples') {
                 timeout(time: 60, unit: 'MINUTES') {
                     sh '''
                         cd CI-Examples/tensorflow-lite
+                        sed -i 's/sgx.enclave_size = "512M"/sgx.enclave_size = "2G"/g' label_image.manifest.template
                         ../common_tools/download --output bazel-0.16.1-installer-linux-x86_64.sh \
                         --sha256 17ab70344645359fd4178002f367885e9019ae7507c9c1ade8220f3628383444 \
                         --url https://github.com/bazelbuild/bazel/releases/download/0.16.1/bazel-0.16.1-installer-linux-x86_64.sh


### PR DESCRIPTION
Enclave size for Tensorflow example is increased.

Please find execution logs as per below,
http://ba5sapp0350:8080/view/Graphene/job/local_ci_graphene_sgx_rhel_client/302/console