### PR TITLE
Disabling node graphene_18.04_5.19 jobs

### DIFF
--- a/pipelines/graphene_nightly_pipeline
+++ b/pipelines/graphene_nightly_pipeline
@@ -23,6 +23,7 @@ pipeline {
                     }
                 }
 
+                /*
 				stage ('Invoke Ubuntu 18.04 with 5.19 Graphene native Suite') {
                     steps {
                         build job: 'local_ci_graphene_native_18.04_5.19', propagate: true, wait: true
@@ -35,7 +36,8 @@ pipeline {
                         build job: 'local_ci_graphene_sgx_18.04_5.19', propagate: true, wait: true
                     }
                 }
-
+                */
+                
                 stage ('Invoke Ubuntu 20.04 with 6.0 Graphene native Jobs') {
                     steps {
                         build job: 'local_ci_graphene_native_20.04_6.0', parameters: [[$class: 'StringParameterValue', name: 'stress_ng_run', value: 'True']], propagate: true, wait: true


### PR DESCRIPTION
Temporarily disabled Jobs for local_ci_graphene_native_18.04_5.19 and local_ci_graphene_sgx_18.04_5.19
Reason for temporary change is - this machine is used by Jitender to run some attestation experiments