### PR TITLE
redis timeout increased for SGX

### DIFF
--- a/ci/lib/stage-test-sgx.jenkinsfile
+++ b/ci/lib/stage-test-sgx.jenkinsfile
@@ -99,7 +99,7 @@ stage('test-sgx') {
     }
 
     try {
-        timeout(time: 15, unit: 'MINUTES') {
+        timeout(time: 20, unit: 'MINUTES') {
             sh '''
                 # TODO this logic is to check both epoll and select varants, and probably
                 # should be split to check both of those separately and on all distros


### PR DESCRIPTION
Execution timeout increased to 20 mins for Redis workload. (only for SGX runs)
SGX:
http://ba5sapp0350:8080/view/Graphene/job/local_ci_graphene_sgx_centos_6.0/588/console