### PR TITLE
Removing the fix for packages for Ubuntu 22.04

### DIFF
--- a/ci/lib/stage-build-sgx.jenkinsfile
+++ b/ci/lib/stage-build-sgx.jenkinsfile
@@ -115,10 +115,8 @@ stage('build') {
 
             if (env.gramine_repo == "unstable") {
                 env.gramine_branch = "unstable-${ubuntu_repo}"
-            } else if (env.gramine_repo == "stable" && (env.ubuntu_repo != "jammy")) {
-                env.gramine_branch = "${ubuntu_repo}"
             } else {
-                env.gramine_branch = "${gramine_repo}"
+                env.gramine_branch = "${ubuntu_repo}"
             }
 
             sh '''


### PR DESCRIPTION
We previously had hack for Ubuntu 22.04 gramine packages repo. Now, it is not needed