### PR TITLE
Disable recvmsg01 test

### DIFF
--- a/ci/dockerfile/ubuntu22.04.dockerfile
+++ b/ci/dockerfile/ubuntu22.04.dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libxml2-dev \
     libxrender1 \
     libxxf86vm1 \
-    linux-headers-generic \
+    linux-headers-5.15.0-25-generic \
     libjudy-dev \
     libpixman-1-dev \
     libipsec-mb-dev \

--- a/ltp_config/ltp_tests.cfg
+++ b/ltp_config/ltp_tests.cfg
@@ -1583,22 +1583,11 @@ must-pass =
     4
     5
 
-# subtest 3: Linux ignores invalid address in recvmsg for stream sockets.
-# subtest 4: Requires MSG_ERRQUEUE support (LTP outputs: "skip MSG_ERRQUEUE test, it's supported
-#            from 3.17").
-# subtest 8: Ancillary data not supported.
-# subtest 9: Requires MSG_OOB support.
-# subtest 10: Requires MSG_ERRQUEUE support (LTP outputs: "skip MSG_ERRQUEUE test, it's supported
-#             from 3.17").
-# subtest 11: Ancillary data not supported.
-# subtest 12: Ancillary data not supported.
+# subtest 8 requires SCM_RIGHTS support (to send an FD from sender to receiver) and doesn't check
+# for errors (Gramine fails with -ENOSYS), leading to a hang on the receiver side because it tries
+# to receive something that was never sent.
 [recvmsg01]
-must-pass =
-    1
-    2
-    5
-    6
-    7
+skip = yes
 
 # MSG_PEEK with UDP sockets not supported currently.
 [recvmsg02]


### PR DESCRIPTION
Linux-headers-generic is not available for Ubuntu 22.04 and disabling recvmsg01