### PR TITLE
Adding support for newer distros and sorting workloads based on distros

### DIFF
--- a/ci/lib/stage-build-gsc.jenkinsfile
+++ b/ci/lib/stage-build-gsc.jenkinsfile
@@ -1,23 +1,24 @@
 stage('Build Workloads') {
-
+    env.config_os = distro_ver.replace("/", "\\/")
     sh '''
         docker system prune -af
         openssl genrsa -3 -out enclave-key.pem 3072
         cp -f config.yaml.template config.yaml
-        sed -i -E 's/Distro: "(.+)"/Distro: "'"$distro_ver"'"/g' config.yaml
+        sed -i -E 's/Distro: "(.+)"/Distro: "'"$config_os"'"/g' config.yaml
     '''
 
     // Build Bash Workload
     try {
-        sh '''
-            if [ "${os_release_id}" = "centos" ]
-            then
-                cp -rf test/centos8-bash.dockerfile test/bash.dockerfile
-            else
+        if ((env.os_release_id == "centos") || env.os_release_id.contains("redhat")) {
+            sh 'cp -rf test/centos8-bash.dockerfile test/bash.dockerfile'
+        } else {
+            sh '''
                 cp -rf test/ubuntu20.04-bash.dockerfile test/bash.dockerfile
                 sed -i -e "s/FROM ubuntu:20.04/FROM $distro_ver/g" test/bash.dockerfile
-            fi
-            docker build --tag bash-test --file test/bash.dockerfile .
+            '''
+        }
+        sh '''
+            docker build --tag bash-test --build-arg BUILD_OS=${distro_ver} --file test/bash.dockerfile .
             ./gsc build -nc --insecure-args bash-test test/ubuntu20.04-bash.manifest
             ./gsc sign-image --remove-gramine-deps bash-test enclave-key.pem
             ./gsc info-image gsc-bash-test
@@ -27,44 +28,38 @@ stage('Build Workloads') {
     // Build Python Latest Workload
     try {
         sh '''
-            if [ "${os_release_id}" = "centos" ]
+            if [ "${os_release_id}" != "debian" ]
             then
-                docker build --tag python --file test/python.dockerfile .
+                docker build --tag gramine_python --build-arg BUILD_OS=${distro_ver} --file test/python.dockerfile .
             fi
-            if [ "${os_release_id}" = "ubuntu" ] || [ "${os_release_id}" = "debian" ]
+            if [ "${distro_ver}" = "debian:11" ]
             then
-                docker pull python
+                docker pull python:bullseye
+                docker image tag python:bullseye gramine_python
             fi
-            ./gsc build -nc --insecure-args python test/generic.manifest
-            ./gsc sign-image --remove-gramine-deps python enclave-key.pem
-            ./gsc info-image gsc-python
+            if [ "${distro_ver}" = "debian:12" ]
+            then
+                docker pull python:bookworm
+                docker image tag python:bookworm gramine_python
+            fi
+            ./gsc build -nc --insecure-args gramine_python test/generic.manifest
+            ./gsc sign-image --remove-gramine-deps gramine_python enclave-key.pem
+            ./gsc info-image gsc-gramine_python
         '''
     } catch (Exception e) {}
 
-    // Build Python Bullseye Workload
-    if (os_release_id != "centos") {
-        try {
-            sh '''
-                docker pull python:bullseye
-                ./gsc build -nc --insecure-args python:bullseye test/generic.manifest
-                ./gsc sign-image --remove-gramine-deps python:bullseye enclave-key.pem
-                ./gsc info-image gsc-python:bullseye
-            '''
-        } catch (Exception e) {}
-    }
-
     // Build Bash HelloWorld Workload
     try {
-        sh '''
-            if [ "${os_release_id}" = "centos" ]
-            then
-                cp -rf test/centos8-helloworld.dockerfile test/helloworld.dockerfile
-            else
+        if ((env.os_release_id == "centos") || env.os_release_id.contains("redhat")) {
+            sh 'cp -rf test/centos8-helloworld.dockerfile test/helloworld.dockerfile'
+        } else {
+            sh '''
                 cp -rf test/ubuntu20.04-hello-world.dockerfile test/helloworld.dockerfile
                 sed -i -e "s/FROM ubuntu:20.04/FROM $distro_ver/g" test/helloworld.dockerfile
-            fi
-
-            docker build --tag helloworld-test --file test/helloworld.dockerfile .
+            '''
+        }
+        sh '''
+            docker build --tag helloworld-test --build-arg BUILD_OS=${distro_ver} --file test/helloworld.dockerfile .
             ./gsc build -nc --insecure-args helloworld-test test/ubuntu20.04-hello-world.manifest
             ./gsc sign-image --remove-gramine-deps helloworld-test enclave-key.pem
             ./gsc info-image gsc-helloworld-test

--- a/ci/lib/stage-test-gsc.jenkinsfile
+++ b/ci/lib/stage-test-gsc.jenkinsfile
@@ -1,8 +1,8 @@
 stage('Test') {
     try {
-        if (env.os_release_id == "debian")
+        if ((env.os_release_id == "debian") || env.os_release_id.contains("redhat")) {
             env.runtime_args = "-c ls"
-        else {
+        } else {
             env.runtime_args = "-c free"
         }
         sh '''
@@ -16,15 +16,7 @@ stage('Test') {
         sh '''
             docker run --device=/dev/sgx_enclave \
                 -v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket \
-                gsc-python -c 'print("HelloWorld!")' 2>&1 | tee python_result
-        '''
-    } catch (Exception e) {}
-
-    try {
-        sh '''
-            docker run --device=/dev/sgx_enclave \
-                -v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket \
-                gsc-python:bullseye -c 'print("HelloWorld!")' 2>&1 | tee python_bullseye_result
+                gsc-gramine_python -c 'print("HelloWorld!")' 2>&1 | tee python_result
         '''
     } catch (Exception e) {}
 

--- a/ci/linux-sgx-gsc-release.jenkinsfile
+++ b/ci/linux-sgx-gsc-release.jenkinsfile
@@ -1,6 +1,8 @@
 node(node_label) {
     env.ORIG_WKSP = env.WORKSPACE
     env.build_ok = true
+    env.DOCKER_BUILDKIT=0
+    env.COMPOSE_DOCKER_CLI_BUILD=0
     try {
         stage('checkout'){
             checkout scm

--- a/gsc/test/centos8-bash.dockerfile
+++ b/gsc/test/centos8-bash.dockerfile
@@ -1,11 +1,19 @@
-From centos:8
+ARG BUILD_OS
 
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* &&\
-    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+From $BUILD_OS
 
-RUN echo 'proxy=http://proxy-dmz.intel.com:911' >> /etc/yum.conf
+ARG BUILD_OS
 
-RUN yum update -y
+RUN if [ "$BUILD_OS" = "centos:8" ]; then \
+    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-* && \
+    echo 'proxy=http://proxy-dmz.intel.com:911' >> /etc/yum.conf; \
+    fi
+
+RUN if [ "$BUILD_OS" = "redhat/ubi8-minimal:8.8" ]; then \
+    microdnf update -y; \
+    else \
+    yum update -y; \
+    fi
 
 CMD ["bash"]
-

--- a/gsc/test/centos8-helloworld.dockerfile
+++ b/gsc/test/centos8-helloworld.dockerfile
@@ -1,10 +1,19 @@
-From centos:8
+ARG BUILD_OS
 
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* &&\
-    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+From $BUILD_OS
 
-RUN echo 'proxy=http://proxy-dmz.intel.com:911' >> /etc/yum.conf
+ARG BUILD_OS
 
-RUN yum update -y
+RUN if [ "$BUILD_OS" = "centos:8" ]; then \
+    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-* && \
+    echo 'proxy=http://proxy-dmz.intel.com:911' >> /etc/yum.conf; \
+    fi
+
+RUN if [ "$BUILD_OS" = "redhat/ubi8-minimal:8.8" ]; then \
+    microdnf update -y; \
+    else \
+    yum update -y; \
+    fi
 
 CMD ["echo", "\"Hello World! Let's check escaped symbols: < & > \""]

--- a/gsc/test/python.dockerfile
+++ b/gsc/test/python.dockerfile
@@ -1,10 +1,12 @@
-From centos:8
+ARG BUILD_OS
 
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* &&\
-    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+FROM $BUILD_OS
 
-RUN echo 'proxy=http://proxy-dmz.intel.com:911' >> /etc/yum.conf
+ARG BUILD_OS
 
-RUN yum update -y && yum install -y python3
+COPY test/setup.sh ./setup.sh
+
+RUN chmod +x ./setup.sh
+RUN /bin/bash -c './setup.sh'
 
 CMD ["python3"]

--- a/gsc/test/setup.sh
+++ b/gsc/test/setup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -ex
+
+if [[ "$BUILD_OS" = *"ubuntu"* ]]; then
+    apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y python3
+elif [[ "$BUILD_OS" = "centos:8" ]]; then
+    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+    echo 'proxy=http://proxy-dmz.intel.com:911' >> /etc/yum.conf && yum update -y && yum install -y python3
+elif [[ "$BUILD_OS" = "redhat/ubi8:8.8" ]]; then
+    yum update -y && yum install -y python3
+elif [[ "$BUILD_OS" = "redhat/ubi8-minimal:8.8" ]]; then
+    microdnf update -y && microdnf install -y python3;
+fi

--- a/test_workloads.py
+++ b/test_workloads.py
@@ -252,7 +252,7 @@ class Test_Workload_Results():
     def test_gsc_bash_workload(self):
         gsc_bash_result = open("bash_result", "r")
         gsc_bash_log = gsc_bash_result.read()
-        if (os_release_id == "debian"):
+        if (os_release_id == "debian") or ("redhat" in os_release_id):
             assert(re.search('boot(.*)home(.*)proc', gsc_bash_log, re.DOTALL))
         else:
             assert(re.search('Mem:(.*)Swap:', gsc_bash_log, re.DOTALL))
@@ -260,13 +260,6 @@ class Test_Workload_Results():
     @pytest.mark.gsc
     def test_gsc_python_workload(self):
         gsc_python_result = open("python_result", "r")
-        gsc_python_log = gsc_python_result.read()
-        assert("HelloWorld!" in gsc_python_log)
-
-    @pytest.mark.gsc
-    @pytest.mark.skipif((os_release_id == 'centos'), reason="Not enabled for Centos")
-    def test_gsc_python_bullseye_workload(self):
-        gsc_python_result = open("python_bullseye_result", "r")
         gsc_python_log = gsc_python_result.read()
         assert("HelloWorld!" in gsc_python_log)
 


### PR DESCRIPTION
Currently not adding new distro like RHEL as part of this commit, But build support is there and it will sort out the workloads based on distro

**Ubuntu 20.04**: http://ba5sapp0350:8080/view/Old%20Graphene%20Jobs/job/anjali_gsc_test_job/85/console
**centos 8**: http://ba5sapp0350:8080/view/Old%20Graphene%20Jobs/job/anjali_gsc_test_job/83/console
**debian**: http://ba5sapp0350:8080/view/Old%20Graphene%20Jobs/job/anjali_gsc_test_job/84/console
**ubi8**: http://ba5sapp0350:8080/view/Old%20Graphene%20Jobs/job/anjali_gsc_test_job/81/console
**ubi8-minimal**: http://ba5sapp0350:8080/view/Old%20Graphene%20Jobs/job/anjali_gsc_test_job/82/console