### PR TITLE
Enable memcached verification and reducing stress-ng time

### DIFF
--- a/ci/lib/stage-test-examples.jenkinsfile
+++ b/ci/lib/stage-test-examples.jenkinsfile
@@ -127,7 +127,7 @@ stage('test-examples') {
     }
 
     if (!((env.no_cpu.toInteger() < 16) && (env.SGX == '1'))) {
-        if (["ubuntu20.04", "rhel8"].contains(env.base_os)) {
+        if (["ubuntu20.04"].contains(env.base_os)) {
             try {
                 timeout(time: 30, unit: 'MINUTES') {
                     sh '''#!/bin/bash

--- a/ci/lib/stage-test-stress-ng.jenkinsfile
+++ b/ci/lib/stage-test-stress-ng.jenkinsfile
@@ -2,7 +2,7 @@ timestamps {
     stage('stress-ng') {
         if ((env.stress_ng_run == "True") && (env.no_cpu.toInteger() > 16)) {
             try {
-                timeout(time: 240, unit: 'MINUTES') {
+                timeout(time: 150, unit: 'MINUTES') {
                     sh '''
                         export cmd=gramine-direct
                         cd CI-Examples/stress-ng

--- a/test_workloads.py
+++ b/test_workloads.py
@@ -41,9 +41,8 @@ class Test_Workload_Results():
             assert("Success SGX quote" in python_contents)
 
     @pytest.mark.examples
-    @pytest.mark.skipif((os_release_id != "ubuntu" or
-                    float(os_version) >= 21),
-                    reason="Memcached libraries not available for CENT/RHEL")
+    @pytest.mark.skipif((os_release_id != "ubuntu"),
+                    reason="Memcached libraries available for Ubuntu")
     def test_memcached_workload(self):
         memcached_result_file = open("CI-Examples/memcached/OUTPUT.txt", "r")
         memcached_contents = memcached_result_file.read()
@@ -182,7 +181,7 @@ class Test_Workload_Results():
             and ("diff -q test_files/gzip test_files/gzip.copy" in gcc_contents))
 
     @pytest.mark.examples
-    @pytest.mark.skipif(not(base_os in ["ubuntu20.04", "rhel8"])
+    @pytest.mark.skipif(not(base_os in ["ubuntu20.04"])
                      or ((int(no_cores) < 16) and sgx_mode == '1'),
                     reason="Openvino enabled only for Ubuntu 20 Server Configurations")
     def test_openvino_workload(self):


### PR DESCRIPTION
Openvino was already disabled earlier, recently enabled it, but it is failing with timeout during model download, so reverting back