### PR TITLE
Fixing max_threads & removing dir from stress-ng

### DIFF
--- a/ci/lib/stage-test-sgx.jenkinsfile
+++ b/ci/lib/stage-test-sgx.jenkinsfile
@@ -163,7 +163,7 @@ stage('test-sgx') {
                 if [ "${no_cpu}" -gt 16 ]
                 then
                     sed -i 's/sgx.enclave_size = "2048M"/sgx.enclave_size = "4G"/g' blender.manifest.template
-                    sed -i 's/sgx.max_threads = 64/sgx.max_threads = 256/g' blender.manifest.template
+                    sed -i 's/sgx.max_threads = {{ .1. if env.get(.EDMM., .0.) == .1. else .64. }}/sgx.max_threads = {{ '"'"'1'"'"' if env.get('"'"'EDMM'"'"', '"'"'0'"'"') == '"'"'1'"'"' else '"'"'256'"'"' }}/g' blender.manifest.template
                 fi
                 make ${MAKEOPTS} all
                 make ${MAKEOPTS} SGX=1 check

--- a/ci/linux-sgx-gcc-release.jenkinsfile
+++ b/ci/linux-sgx-gcc-release.jenkinsfile
@@ -8,6 +8,7 @@ node (node_label) {
 
         dir ("gramine") {
             env.SGX = '1'
+            env.EDMM = '1'
             sh '../ci/resources/setup_workspace.sh'
             env.WORKSPACE = env.WORKSPACE + "/gramine"
 

--- a/stress-ng/filesystem.job
+++ b/stress-ng/filesystem.job
@@ -128,7 +128,7 @@ dentry 0		# 0 means 1 stressor per CPU
 #   start N workers that create and remove directories  using  mkdir
 #   and rmdir.
 #
-dir 0			# 0 means 1 stressor per CPU
+# dir 0			# 0 means 1 stressor per CPU
 # dir-ops 1000000	# stop after 1000000 bogo ops
 # dir-dirs 8192		# exercise 8192 directories per stressor
 

--- a/stress-ng/filesystem_all.job
+++ b/stress-ng/filesystem_all.job
@@ -128,9 +128,9 @@ dentries 2048		# create 2048 dentries per stress iteration
 #   start N workers that create and remove directories  using  mkdir
 #   and rmdir.
 #
-dir 0			# 0 means 1 stressor per CPU
-dir-ops 1000000	# stop after 1000000 bogo ops
-dir-dirs 8192		# exercise 8192 directories per stressor
+# dir 0			# 0 means 1 stressor per CPU
+# dir-ops 1000000	# stop after 1000000 bogo ops
+# dir-dirs 8192		# exercise 8192 directories per stressor
 
 #
 # dirdeep stressor options:


### PR DESCRIPTION
Added EDMM=1 for SGX, to support today nightly runs