### PR TITLE
Fix for getpid issue

### DIFF
--- a/ltp_src/testcases/kernel/syscalls/getpid/getpid01.c
+++ b/ltp_src/testcases/kernel/syscalls/getpid/getpid01.c
@@ -40,4 +40,5 @@ static void verify_getpid(void)
 static struct tst_test test = {
 	.forks_child = 1,
 	.test_all = verify_getpid,
+	.max_runtime = 300,
 };


### PR DESCRIPTION
With upgraded LTP, timeout specified for individual test is not taking effect, which was causing this test to fail

Latest Logs:
[0.711] /home/bits/jenkins/workspace/local_ci_graphene_sgx_dcap/gramine/libos/test/ltp/ltp_src/lib/tst_test.c:1558: TINFO: Timeout per run is 0h 00m 30s

Old Logs:
[0.678] /home/bits/jenkins/workspace/local_ci_graphene_sgx_dcap/gramine/libos/test/ltp/ltp_src/lib/tst_test.c:1362: TINFO: Timeout per run is 0h 05m 00s

[gramine_sgx-getpid01.log](https://github.com/jinengandhi-intel/graphene_local_ci/files/14206243/gramine_sgx-getpid01.log)
