### PR TITLE
Jenkins Fixes for docker related failures in  Debian12

### DIFF
--- a/ci/lib/stage-build-gsc.jenkinsfile
+++ b/ci/lib/stage-build-gsc.jenkinsfile
@@ -96,8 +96,9 @@ stage('Build and Test Workloads') {
         } catch (Exception e) { } 
         finally {
             sh '''
+                # Remove containers with Error Handling - Avoid error in finally block
                 if [ -n "$(docker ps -a -q --filter ancestor=gsc-java-spring-boot-test)" ]; then
-                    docker rm $(docker stop $(docker ps -a -q --filter ancestor=gsc-java-spring-boot-test) &>/dev/null) &>/dev/null
+                    docker rm $(docker stop $(docker ps -a -q --filter ancestor=gsc-java-spring-boot-test) &>/dev/null) &>/dev/null || true
                 fi
             '''
         }
@@ -128,8 +129,15 @@ stage('Build and Test Workloads') {
         } catch (Exception e) { } 
         finally {
             sh '''
-                docker rm $(docker stop $(docker ps -a -q) &>/dev/null) &>/dev/null 
-                docker rmi verifier:latest &>/dev/null
+                # Remove containers with Error Handling - Avoid error in finally block
+                if [ -n "$(docker ps -aq)" ]; then
+                    docker rm $(docker stop $(docker ps -aq) &>/dev/null) &>/dev/null || true
+                fi
+
+                # Remove images with Error Handling - Avoid error in finally block
+                if [ -n "$(docker image ls --filter=reference=verifier -q)" ]; then
+                    docker rmi verifier:latest &>/dev/null || true
+                fi
             '''
         }
 
@@ -157,8 +165,15 @@ stage('Build and Test Workloads') {
         } catch (Exception e) { } 
         finally {
             sh '''
-                docker rm $(docker stop $(docker ps -a -q) &>/dev/null) &>/dev/null 
-                docker rmi verifier:latest &>/dev/null
+                # Remove containers with Error Handling - Avoid error in finally block
+                if [ -n "$(docker ps -aq)" ]; then
+                    docker rm $(docker stop $(docker ps -aq) &>/dev/null) &>/dev/null || true
+                fi
+
+                # Remove images with Error Handling - Avoid error in finally block
+                if [ -n "$(docker image ls --filter=reference=verifier -q)" ]; then
+                    docker rmi verifier:latest &>/dev/null || true
+                fi
             '''
         }
 
@@ -186,8 +201,15 @@ stage('Build and Test Workloads') {
         } catch (Exception e) { } 
         finally {
             sh '''
-                docker rm $(docker stop $(docker ps -a -q) &>/dev/null) &>/dev/null 
-                docker rmi verifier:latest &>/dev/null
+                # Remove containers with Error Handling - Avoid error in finally block
+                if [ -n "$(docker ps -aq)" ]; then
+                    docker rm $(docker stop $(docker ps -aq) &>/dev/null) &>/dev/null || true
+                fi
+
+                # Remove images with Error Handling - Avoid error in finally block
+                if [ -n "$(docker image ls --filter=reference=verifier -q)" ]; then
+                    docker rmi verifier:latest &>/dev/null  || true
+                fi
             '''
         }
 
@@ -219,15 +241,23 @@ stage('Build and Test Workloads') {
         } catch (Exception e) { } 
         finally {
             sh '''
-                if [ -n "$(docker ps -a -q --filter ancestor=verifier) " ]; then
-                    docker rm $(docker stop $(docker ps -a -q --filter ancestor=verifier) &>/dev/null) &>/dev/null
+                # Remove containers with Error Handling - Avoid error in finally block
+                if [ -n "$(docker ps -a -q --filter ancestor=verifier)" ]; then
+                    docker rm $(docker stop $(docker ps -a -q --filter ancestor=verifier) &>/dev/null) &>/dev/null || true
                 fi
 
-                if [ -n "$(docker ps -a -q --filter ancestor=gsc-ovms-image) " ]; then
-                    docker rm $(docker stop $(docker ps -a -q --filter ancestor=gsc-ovms-image) &>/dev/null) &>/dev/null
+                if [ -n "$(docker ps -a -q --filter ancestor=gsc-ovms-image)" ]; then
+                    docker rm $(docker stop $(docker ps -a -q --filter ancestor=gsc-ovms-image) &>/dev/null) &>/dev/null || true
                 fi
                 
-                docker rmi verifier:latest gsc-ovms-image &>/dev/null
+                # Remove Images with Error Handling - Avoid error in finally block
+                if [ -n "$(docker image ls --filter=reference=gsc-ovms-image -q)" ]; then
+                    docker rmi gsc-ovms-image &>/dev/null || true
+                fi
+
+                if [ -n "$(docker image ls --filter=reference=verifier -q)" ]; then
+                    docker rmi verifier &>/dev/null || true
+                fi
             '''
         }
     }


### PR DESCRIPTION
Overview:
Added additional error handling in the finally block for failing 22.04 tests


Stable results after multiple validation runs:
Ubuntu:22.04: Pipeline going till verification stage -
 [(http://10.99.116.103:8080/job/local_ci_graphene_gsc/3289/console)](http://10.99.116.103:8080/job/local_ci_graphene_gsc/3289/console)
[(http://10.99.116.103:8080/job/local_ci_graphene_gsc/3304/console)](http://10.99.116.103:8080/job/local_ci_graphene_gsc/3304/console)
[(http://10.99.116.103:8080/job/local_ci_graphene_gsc/3306/console)](http://10.99.116.103:8080/job/local_ci_graphene_gsc/3306/console)

Debian:12: Pipeline going till verification stage - 
[(http://10.99.116.103:8080/job/local_ci_graphene_gsc/3292/console)](http://10.99.116.103:8080/job/local_ci_graphene_gsc/3292/console)
[(http://10.99.116.103:8080/job/local_ci_graphene_gsc/3303/console)](http://10.99.116.103:8080/job/local_ci_graphene_gsc/3303/console)
[(http://10.99.116.103:8080/job/local_ci_graphene_gsc/3305/console)](http://10.99.116.103:8080/job/local_ci_graphene_gsc/3305/console)